### PR TITLE
Automate input normalisation

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -238,6 +238,7 @@ def parse_args(argv=None):
         choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
         default="WARNING",
     )
+    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
     return parser.parse_args(argv)
 
 

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -21,7 +21,7 @@ process SAMPLESHEET_CHECK {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        python: \$(python --version | sed 's/Python //g')
+        check_samplesheet.py: \$(check_samplesheet.py --version | cut -d' ' -f2)
     END_VERSIONS
     """
 }

--- a/modules/local/samplesheet_check.nf
+++ b/modules/local/samplesheet_check.nf
@@ -1,5 +1,6 @@
 process SAMPLESHEET_CHECK {
     tag "$samplesheet"
+    label 'process_single'
 
     conda (params.enable_conda ? "conda-forge::python=3.8.3" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?


### PR DESCRIPTION
Hi @ksenia-krasheninnikova 

We're coming up with a guideline for versioning scripts, and this PR is to bring those changes to this repo. When you get to work on the automate_io subworkflow, take a look at https://github.com/sanger-tol/nf-core-pipeline/blob/main/subworkflows/automate_input/bin/tol_input.sh#L5 and https://github.com/sanger-tol/nf-core-pipeline/blob/main/subworkflows/automate_input/modules/local/input_tol.nf#L27 and make sure you've version your script.

Also, can you consider doing the same for your own scripts ? They're all essentially one-liners to add, and then the scripts are versioned and it's clear which version of the script was used.

Thanks !