### PR TITLE
Version check_samplesheet.py

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -238,6 +238,7 @@ def parse_args(argv=None):
         choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
         default="WARNING",
     )
+    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
     return parser.parse_args(argv)
 
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -238,7 +238,7 @@ def parse_args(argv=None):
         choices=("CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"),
         default="WARNING",
     )
-    parser.add_argument('--version', action='version', version='%(prog)s 1.0')
+    parser.add_argument("--version", action="version", version="%(prog)s 1.0")
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
Hi @ksenia-krasheninnikova 

We're coming up with a guideline for versioning scripts, starting with the automate_io subworkflow. I know you're not using it any more, so this PR is more about keeping you up-to-date.

For Python scripts, support for `--version` can be added with a one-liner like this. Then, the `.nf` shoud call that rather printing the Python version, cf https://github.com/sanger-tol/nf-core-pipeline/blob/main/subworkflows/automate_input/modules/local/samplesheet_check.nf#L24

For shell scripts, you can add a one-liner in your shell script to check that the number of arguments is correct, and print a short usage message + version otherwise. See https://github.com/sanger-tol/nf-core-pipeline/blob/main/subworkflows/automate_input/bin/tol_input.sh#L5 and https://github.com/sanger-tol/nf-core-pipeline/blob/main/subworkflows/automate_input/modules/local/input_tol.nf#L27

Can you consider doing the same for your own scripts ? They're all essentially very easy to add, and then the scripts are versioned and it's clear which version of the script was used.

Thanks !