### PR TITLE
Update of hifiasm version

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -110,7 +110,7 @@
                     },
                     "hifiasm": {
                         "branch": "master",
-                        "git_sha": "07b737b47d33d8d980e5e0c09736764f450980a3",
+                        "git_sha": "aecb06fcdb995ff3e3df7c7a1fd119367d6d1996",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/hifiasm/hifiasm.diff"
                     },

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -1,0 +1,8 @@
+name: hifiasm
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::hifiasm=0.19.8
+  - biioconda::samtools=1.20

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -1,8 +1,0 @@
-name: hifiasm
-channels:
-  - conda-forge
-  - bioconda
-  - defaults
-dependencies:
-  - bioconda::hifiasm=0.19.8
-  - bioconda::samtools=1.20

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -5,4 +5,4 @@ channels:
   - defaults
 dependencies:
   - bioconda::hifiasm=0.19.8
-  - biioconda::samtools=1.20
+  - bioconda::samtools=1.20

--- a/modules/nf-core/hifiasm/hifiasm.diff
+++ b/modules/nf-core/hifiasm/hifiasm.diff
@@ -47,5 +47,16 @@ Changes in module 'nf-core/hifiasm'
      if ((paternal_kmer_dump) && (maternal_kmer_dump) && (hic_read1) && (hic_read2)) {
          error "Hifiasm Trio-binning and Hi-C integrated should not be used at the same time"
      } else if ((paternal_kmer_dump) && !(maternal_kmer_dump)) {
+@@ -67,8 +73,8 @@
+             $args \\
+             -o ${prefix}.asm \\
+             -t $task.cpus \\
+-            --h1 $hic_read1 \\
+-            --h2 $hic_read2 \\
++            --h1 <($hic_read1) \\
++            --h2 <($hic_read2) \\
+             $reads \\
+             2> >( tee ${prefix}.stderr.log >&2 )
+ 
 
 ************************************************************

--- a/modules/nf-core/hifiasm/hifiasm.diff
+++ b/modules/nf-core/hifiasm/hifiasm.diff
@@ -1,24 +1,23 @@
 Changes in module 'nf-core/hifiasm'
 --- modules/nf-core/hifiasm/main.nf
 +++ modules/nf-core/hifiasm/main.nf
-@@ -2,10 +2,13 @@
+@@ -2,10 +2,11 @@
      tag "$meta.id"
      label 'process_high'
  
--    conda "bioconda::hifiasm=0.18.5"
+-    conda "${moduleDir}/environment.yml"
+-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+-        'https://depot.galaxyproject.org/singularity/hifiasm:0.19.8--h43eeafb_0' :
+-        'biocontainers/hifiasm:0.19.8--h43eeafb_0' }"
 +    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
 +        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
 +    }
 +
-     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
--        'https://depot.galaxyproject.org/singularity/hifiasm:0.18.5--h5b5514e_0' :
--        'quay.io/biocontainers/hifiasm:0.18.5--h5b5514e_0' }"
-+        'https://depot.galaxyproject.org/singularity/mulled-v2-8019bff5bdc04e0e88980d5ba292ba022fec5dd9:56ed7e3ac0e84e7d947af98abfb86dda9e1dc9f8-0' :
-+        'quay.io/biocontainers/mulled-v2-8019bff5bdc04e0e88980d5ba292ba022fec5dd9:56ed7e3ac0e84e7d947af98abfb86dda9e1dc9f8-0' }"
++    container "wave.seqera.io/wt/73ac3caec075/wave/build:hifiasm-0.19.8_samtools-1.20--1f6824530f0d0ad5"
  
      input:
      tuple val(meta), path(reads)
-@@ -13,6 +16,7 @@
+@@ -13,6 +14,7 @@
      path  maternal_kmer_dump
      path  hic_read1
      path  hic_read2
@@ -26,7 +25,7 @@ Changes in module 'nf-core/hifiasm'
  
      output:
      tuple val(meta), path("*.r_utg.gfa")       , emit: raw_unitigs
-@@ -22,8 +26,10 @@
+@@ -23,8 +25,10 @@
      tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
      tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
      tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
@@ -36,15 +35,15 @@ Changes in module 'nf-core/hifiasm'
 +    tuple val(meta), path("*.asm.hic.a_ctg.gfa")   , emit: hic_alternate_contigs  , optional: true
 +    tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true
 +    tuple val(meta), path("*.asm.hic.hap2.p_ctg.gfa")  , emit: maternal_contigs , optional: true
+     tuple val(meta), path("*.log")             , emit: log
      path  "versions.yml"                       , emit: versions
  
-     when:
-@@ -32,6 +38,8 @@
+@@ -34,6 +38,8 @@
      script:
      def args = task.ext.args ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
-+    def hic_read1 = hic_reads_cram ? "<( samtools cat $hic_reads_cram | samtools fastq -n -f0x40 -F0xB00 )" : ""
-+    def hic_read2 = hic_reads_cram ? "<( samtools cat $hic_reads_cram | samtools fastq -n -f0x80 -F0xB00 )" : ""
++    def hic_read1 = hic_reads_cram ? "for f in $hic_reads_cram; do samtools cat \$f | samtools fastq -n -f0x40 -F0xB00; done" : ""
++    def hic_read2 = hic_reads_cram ? "for f in $hic_reads_cram; do samtools cat \$f | samtools fastq -n -f0x80 -F0xB00; done" : ""
      if ((paternal_kmer_dump) && (maternal_kmer_dump) && (hic_read1) && (hic_read2)) {
          error "Hifiasm Trio-binning and Hi-C integrated should not be used at the same time"
      } else if ((paternal_kmer_dump) && !(maternal_kmer_dump)) {

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -6,7 +6,7 @@ process HIFIASM {
         exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
 
-    container "wave.seqera.io/wt/73ac3caec075/wave/build:hifiasm-0.19.8_samtools-1.20--1f6824530f0d0ad5"
+    container "quay.io/sanger-tol/hifiasm_samtools:0.01"
 
     input:
     tuple val(meta), path(reads)

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -6,9 +6,7 @@ process HIFIASM {
         exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
     }
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/mulled-v2-8019bff5bdc04e0e88980d5ba292ba022fec5dd9:56ed7e3ac0e84e7d947af98abfb86dda9e1dc9f8-0' :
-        'quay.io/biocontainers/mulled-v2-8019bff5bdc04e0e88980d5ba292ba022fec5dd9:56ed7e3ac0e84e7d947af98abfb86dda9e1dc9f8-0' }"
+    container "wave.seqera.io/wt/73ac3caec075/wave/build:hifiasm-0.19.8_samtools-1.20--1f6824530f0d0ad5"
 
     input:
     tuple val(meta), path(reads)
@@ -23,6 +21,7 @@ process HIFIASM {
     tuple val(meta), path("*.ec.bin")          , emit: corrected_reads
     tuple val(meta), path("*.ovlp.source.bin") , emit: source_overlaps
     tuple val(meta), path("*.ovlp.reverse.bin"), emit: reverse_overlaps
+    tuple val(meta), path("*.bp.p_ctg.gfa")    , emit: processed_contigs, optional: true
     tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
     tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
     tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
@@ -30,6 +29,7 @@ process HIFIASM {
     tuple val(meta), path("*.asm.hic.a_ctg.gfa")   , emit: hic_alternate_contigs  , optional: true
     tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true
     tuple val(meta), path("*.asm.hic.hap2.p_ctg.gfa")  , emit: maternal_contigs , optional: true
+    tuple val(meta), path("*.log")             , emit: log
     path  "versions.yml"                       , emit: versions
 
     when:
@@ -54,7 +54,9 @@ process HIFIASM {
             -t $task.cpus \\
             -1 $paternal_kmer_dump \\
             -2 $maternal_kmer_dump \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 )
+
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -73,7 +75,9 @@ process HIFIASM {
             -t $task.cpus \\
             --h1 <($hic_read1) \\
             --h2 <($hic_read2) \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 )
+
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -86,7 +90,8 @@ process HIFIASM {
             $args \\
             -o ${prefix}.asm \\
             -t $task.cpus \\
-            $reads
+            $reads \\
+            2> >( tee ${prefix}.stderr.log >&2 )
 
         cat <<-END_VERSIONS > versions.yml
         "${task.process}":
@@ -94,4 +99,26 @@ process HIFIASM {
         END_VERSIONS
         """
     }
+        stub:
+        def args = task.ext.args ?: ''
+        def prefix = task.ext.prefix ?: "${meta.id}"
+        """
+        touch ${prefix}.asm.r_utg.gfa
+        touch ${prefix}.asm.ec.bin
+        touch ${prefix}.asm.ovlp.source.bin
+        touch ${prefix}.asm.ovlp.reverse.bin
+        touch ${prefix}.asm.bp.p_ctg.gfa
+        touch ${prefix}.asm.p_utg.gfa
+        touch ${prefix}.asm.p_ctg.gfa
+        touch ${prefix}.asm.a_ctg.gfa
+        touch ${prefix}.asm.hap1.p_ctg.gfa
+        touch ${prefix}.asm.hap2.p_ctg.gfa
+        touch ${prefix}.stderr.log
+
+        cat <<-END_VERSIONS > versions.yml
+        "${task.process}":
+            hifiasm: \$(hifiasm --version 2>&1)
+        END_VERSIONS
+        """
+
 }

--- a/modules/nf-core/hifiasm/meta.yml
+++ b/modules/nf-core/hifiasm/meta.yml
@@ -15,7 +15,6 @@ tools:
       tool_dev_url: https://github.com/chhylp123/hifiasm
       doi: "10.1038/s41592-020-01056-5"
       licence: ["MIT"]
-
 input:
   - meta:
       type: map
@@ -33,7 +32,7 @@ input:
       type: file
       description: Yak kmer dump file for maternal reads (can be used for haplotype resolution). It can have an arbitrary extension.
   - use_parental_kmers:
-      type: logical
+      type: boolean
       description: A flag (true or false) signalling if the module should use the paternal and maternal kmer dumps.
   - hic_read1:
       type: file
@@ -41,7 +40,6 @@ input:
   - hic_read2:
       type: file
       description: Hi-C data Reverse reads.
-
 output:
   - meta:
       type: map
@@ -88,7 +86,14 @@ output:
       type: file
       description: Reverse overlaps
       pattern: "*.ovlp.reverse.bin"
-
+  - log:
+      type: file
+      description: Stderr log
+      pattern: "*.log"
 authors:
+  - "@sidorov-si"
+  - "@scorreard"
+  - "@mbeavitt"
+maintainers:
   - "@sidorov-si"
   - "@scorreard"


### PR DESCRIPTION
The hifiasm patch facilitates piping in HiC data directly from CRAM using `samtools fastq` without creating intermediate FASTQ files.
This update is aimed at updating hifiasm to the latest version (0.19.8).
For this purpose wave-cli was used and a new wave container was generated.

Since all containers kept by the native wave infrastructure are deleted in a week - should it be moved from

`wave.seqera.io/wt/73ac3caec075/wave/build:hifiasm-0.19.8_samtools-1.20--1f6824530f0d0ad5`

to the private repo and in this case do we have a ToL repo for that?

Otherwise, there is a way of building a container with wave inside of the project with Dockerfile:
https://www.nextflow.io/docs/latest/wave.html#build-module-containers

UPD:
In the course of working on the PR it was revealed that nf-core wave functionality has not been fully implemented to be built into the workflow. The combined image of hifiasm and samtools was created with wave-cli and will be hosted for now at quay.io/sanger-tol.
The command used to build the image:
`wave-1.3.0-linux-x86_64 --conda-package hifiasm=0.19.8 --conda-package samtools=1.20`

<!--
# sanger-tol/genomeassembly pull request

Many thanks for contributing to sanger-tol/genomeassembly!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
