### PR TITLE
hap1/hap2 scaffolding

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -642,7 +642,7 @@ process {
     }
 
     // Scaffolding hap1/hap2 
-
+    if (params.hifiasm_hic_on) {
     // hap1 scaffolding
 
     withName: '.*HIC_MAPPING_HAP1:SAMTOOLS_MARKDUP_HIC_MAPPING' {
@@ -839,7 +839,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-
+    }
     // End of hap2 scaffolding
 
     withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_PRI' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,7 +166,7 @@ process {
             ]
         }
 
-        withName: '.*GENOME_STATISTICS_RAW_HIC:GFASTATS_ALT' {
+        withName: '.*GENOME_STATISTICS_RAW_HIC:GFASTATS_HAP' {
             ext.prefix = { "${meta.id}.asm.hic.hap2" }
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}" },
@@ -174,6 +174,7 @@ process {
                 pattern: '*assembly_summary'
             ]
         }
+
         withName: '.*GENOME_STATISTICS_RAW_HIC:BUSCO' {
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.p_ctg.${meta.lineage}.busco" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -132,8 +132,8 @@ process {
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
         }
-        withName: '.*RAW_ASSEMBLY:GFA_TO_FASTA_PRI_HIC' {
-            ext.prefix = { "${meta.id}.asm.hic.p_ctg" }
+        withName: '.*RAW_ASSEMBLY:GFA_TO_FASTA_HAP1_HIC' {
+            ext.prefix = { "${meta.id}.asm.hic.hap1" }
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}" },
                 mode: params.publish_dir_mode,
@@ -141,8 +141,8 @@ process {
             ]
         }
 
-        withName: '.*RAW_ASSEMBLY:GFA_TO_FASTA_ALT_HIC' {
-            ext.prefix = { "${meta.id}.asm.hic.a_ctg" }
+        withName: '.*RAW_ASSEMBLY:GFA_TO_FASTA_HAP2_HIC' {
+            ext.prefix = { "${meta.id}.asm.hic.hap2" }
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}" },
                 mode: params.publish_dir_mode,
@@ -158,7 +158,7 @@ process {
             ]
         }
         withName: '.*GENOME_STATISTICS_RAW_HIC:GFASTATS_PRI' {
-            ext.prefix = { "${meta.id}.asm.hic.p_ctg" }
+            ext.prefix = { "${meta.id}.asm.hic.hap1" }
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}" },
                 mode: params.publish_dir_mode,
@@ -166,8 +166,8 @@ process {
             ]
         }
 
-        withName: '.*GENOME_STATISTICS_RAW_HIC:GFASTATS_HAP' {
-            ext.prefix = { "${meta.id}.asm.hic.a_ctg" }
+        withName: '.*GENOME_STATISTICS_RAW_HIC:GFASTATS_ALT' {
+            ext.prefix = { "${meta.id}.asm.hic.hap2" }
             publishDir = [
                 path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}" },
                 mode: params.publish_dir_mode,
@@ -189,7 +189,7 @@ process {
 
         withName: '.*GENOME_STATISTICS_RAW_HIC:MERQURYFK_MERQURYFK' {
             publishDir = [
-                path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.p_ctg.ccs.merquryk" },
+                path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.hap1.ccs.merquryk" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
@@ -499,7 +499,7 @@ process {
         ]
     }
 
-    withName: '.*HIC_MAPPING:SAMTOOLS_MERGE_HIC_MAPPING' {
+    withName: '.*HIC_MAPPING.*:SAMTOOLS_MERGE_HIC_MAPPING' {
         ext.prefix  = { "${meta.id}_merged" }
     }
 
@@ -530,7 +530,7 @@ process {
     }
 
 
-    withName: '.*HIC_MAPPING:CONVERT_STATS:SAMTOOLS_VIEW' {
+    withName: '.*HIC_MAPPING.*:CONVERT_STATS:SAMTOOLS_VIEW' {
         ext.args = "--output-fmt cram"
     }
 
@@ -559,7 +559,7 @@ process {
     }
 
     // Set up of the scffolding pipeline
-    withName: 'YAHS' {
+    withName: '.*SCAFFOLDING:YAHS' {
         ext.prefix = 'out'
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasm}/scaffolding/yahs/out.break.yahs" },
@@ -568,7 +568,7 @@ process {
         ]
     }
 
-    withName: 'COOLER_CLOAD' {
+    withName: '.*SCAFFOLDING:COOLER_CLOAD' {
         // Positions in the input file are zero-based;
         // chrom1 field number (one-based) is 2;
         // pos1 field number (one-based) is 3;
@@ -582,7 +582,7 @@ process {
         ]
     }
 
-    withName: 'PRETEXTSNAPSHOT' {
+    withName: '.*SCAFFOLDING:PRETEXTSNAPSHOT' {
         // Make one plot containing all sequences
         ext.args = '--sequences \"=full\"'
         publishDir = [
@@ -592,7 +592,7 @@ process {
         ]
     }
 
-    withName: 'JUICER_TOOLS_PRE' {
+    withName: '.*SCAFFOLDING:JUICER_TOOLS_PRE' {
         ext.juicer_tools_jar = 'juicer_tools.1.9.9_jcuda.0.8.jar'
         ext.juicer_jvm_params = '-Xms1g -Xmx6g'
         publishDir = [
@@ -602,7 +602,7 @@ process {
         ]
     }
 
-    withName: 'JUICER_PRE' {
+    withName: '.*SCAFFOLDING:JUICER_PRE' {
         ext.args2 = "LC_ALL=C sort -k2,2d -k6,6d -S50G | awk '\$3>=0 && \$7>=0'"
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasm}/scaffolding/yahs/out.break.yahs" },
@@ -640,7 +640,241 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
+
+    // Scaffolding hap1/hap2 
+
+    // hap1 scaffolding
+
+    withName: '.*HIC_MAPPING_HAP1:SAMTOOLS_MARKDUP_HIC_MAPPING' {
+        ext.prefix  = { "${meta.id}_mkdup" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP1:BAMTOBED_SORT' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+
+    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_STATS' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_FLAGSTAT' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_IDXSTATS' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP1:YAHS' {
+        ext.prefix = 'out'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+
+    }
+
+    withName: '.*SCAFFOLDING_HAP1:COOLER_CLOAD' {
+        // Positions in the input file are zero-based;
+        // chrom1 field number (one-based) is 2;
+        // pos1 field number (one-based) is 3;
+        // chrom2 field number (one-based) is 6;
+        // pos2 field number (one-based) is 7
+        ext.args = 'pairs -0 -c1 2 -p1 3 -c2 6 -p2 7'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP1:PRETEXTSNAPSHOT' {
+        // Make one plot containing all sequences
+        ext.args = '--sequences \"=full\"'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP1:JUICER_TOOLS_PRE' {
+        ext.juicer_tools_jar = 'juicer_tools.1.9.9_jcuda.0.8.jar'
+        ext.juicer_jvm_params = '-Xms1g -Xmx6g'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP1:JUICER_PRE' {
+        ext.args2 = "LC_ALL=C sort -k2,2d -k6,6d -S50G | awk '\$3>=0 && \$7>=0'"
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+
+    // End of hap1 scaffolding
+
+    // hap2 scaffolding
+    
+    withName: '.*HIC_MAPPING_HAP2:SAMTOOLS_MARKDUP_HIC_MAPPING' {
+        ext.prefix  = { "${meta.id}_mkdup" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP2:BAMTOBED_SORT' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+
+    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_STATS' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_FLAGSTAT' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_IDXSTATS' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP2:YAHS' {
+        ext.prefix = 'out'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+
+    }
+
+    withName: '.*SCAFFOLDING_HAP2:COOLER_CLOAD' {
+        // Positions in the input file are zero-based;
+        // chrom1 field number (one-based) is 2;
+        // pos1 field number (one-based) is 3;
+        // chrom2 field number (one-based) is 6;
+        // pos2 field number (one-based) is 7
+        ext.args = 'pairs -0 -c1 2 -p1 3 -c2 6 -p2 7'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP2:PRETEXTSNAPSHOT' {
+        // Make one plot containing all sequences
+        ext.args = '--sequences \"=full\"'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP2:JUICER_TOOLS_PRE' {
+        ext.juicer_tools_jar = 'juicer_tools.1.9.9_jcuda.0.8.jar'
+        ext.juicer_jvm_params = '-Xms1g -Xmx6g'
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: '.*SCAFFOLDING_HAP2:JUICER_PRE' {
+        ext.args2 = "LC_ALL=C sort -k2,2d -k6,6d -S50G | awk '\$3>=0 && \$7>=0'"
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // End of hap2 scaffolding
+
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_PRI' {
+        ext.prefix = { "${meta.id}_scaffolds_final" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            pattern: '*assembly_summary'
+        ]
+    }
+
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:BUSCO' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.endsWith('busco.log') ? filename :
+                    filename.endsWith('full_table.tsv') ? filename :
+                    filename.endsWith('missing_busco_list.tsv') ? filename :
+                    filename.startsWith('short_summary') ? filename :
+                    filename.endsWith('busco.batch_summary.txt') ? filename :
+                    null }
+        ]
+    }
+
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:MERQURYFK_MERQURYFK' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs/out_scaffolds_final.ccs.merquryk" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    // End of Scaffolding hap1/hap2
     // End of Set up of the scaffolding  pipeline
+
 
     //Set up of assembly stats subworkflow
     withName: 'BUSCO' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -689,7 +689,7 @@ process {
     }
 
     withName: '.*SCAFFOLDING_HAP1:YAHS' {
-        ext.prefix = 'out'
+        ext.prefix = 'hap1'
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
@@ -789,7 +789,7 @@ process {
     }
 
     withName: '.*SCAFFOLDING_HAP2:YAHS' {
-        ext.prefix = 'out'
+        ext.prefix = 'hap2'
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
@@ -852,7 +852,7 @@ process {
         ]
     }
 
-    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_ALT' {
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_HAP' {
         ext.prefix = { "${meta.id}_scaffolds_final" }
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -845,7 +845,16 @@ process {
     withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_PRI' {
         ext.prefix = { "${meta.id}_scaffolds_final" }
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            mode: params.publish_dir_mode,
+            pattern: '*assembly_summary'
+        ]
+    }
+
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_ALT' {
+        ext.prefix = { "${meta.id}_scaffolds_final" }
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             pattern: '*assembly_summary'
         ]
@@ -853,7 +862,7 @@ process {
 
     withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:BUSCO' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.endsWith('busco.log') ? filename :
                     filename.endsWith('full_table.tsv') ? filename :
@@ -866,7 +875,7 @@ process {
 
     withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:MERQURYFK_MERQURYFK' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding/yahs/out.break.yahs/out_scaffolds_final.ccs.merquryk" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs/out_scaffolds_final.ccs.merquryk" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -657,61 +657,60 @@ process {
 
     // Scaffolding hap1/hap2
     if (params.hifiasm_hic_on) {
-    // hap1 scaffolding
 
-    withName: '.*HIC_MAPPING_HAP1:SAMTOOLS_MARKDUP_HIC_MAPPING' {
+    withName: '.*HIC_MAPPING_HAP.*:SAMTOOLS_MARKDUP_HIC_MAPPING' {
         ext.prefix  = { "${meta.id}_mkdup" }
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*HIC_MAPPING_HAP1:BAMTOBED_SORT' {
+    withName: '.*HIC_MAPPING_HAP.*:BAMTOBED_SORT' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
 
-    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_STATS' {
+    withName: '.*HIC_MAPPING_HAP.*:CONVERT_STATS:SAMTOOLS_STATS' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_FLAGSTAT' {
+    withName: '.*HIC_MAPPING_HAP.*:CONVERT_STATS:SAMTOOLS_FLAGSTAT' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*HIC_MAPPING_HAP1:CONVERT_STATS:SAMTOOLS_IDXSTATS' {
+    withName: '.*HIC_MAPPING_HAP.*:CONVERT_STATS:SAMTOOLS_IDXSTATS' {
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*SCAFFOLDING_HAP1:YAHS' {
-        ext.prefix = 'hap1'
+    withName: '.*SCAFFOLDING_HAP.*:YAHS' {
+        ext.prefix = { "${meta.hap_id}" }
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
 
     }
 
-    withName: '.*SCAFFOLDING_HAP1:COOLER_CLOAD' {
+    withName: '.*SCAFFOLDING_HAP.*:COOLER_CLOAD' {
         // Positions in the input file are zero-based;
         // chrom1 field number (one-based) is 2;
         // pos1 field number (one-based) is 3;
@@ -719,142 +718,43 @@ process {
         // pos2 field number (one-based) is 7
         ext.args = 'pairs -0 -c1 2 -p1 3 -c2 6 -p2 7'
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*SCAFFOLDING_HAP1:PRETEXTSNAPSHOT' {
+    withName: '.*SCAFFOLDING_HAP.*:PRETEXTSNAPSHOT' {
         // Make one plot containing all sequences
         ext.args = '--sequences \"=full\"'
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*SCAFFOLDING_HAP1:JUICER_TOOLS_PRE' {
+    withName: '.*SCAFFOLDING_HAP.*:JUICER_TOOLS_PRE' {
         ext.juicer_tools_jar = 'juicer_tools.1.9.9_jcuda.0.8.jar'
         ext.juicer_jvm_params = '-Xms1g -Xmx6g'
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
 
-    withName: '.*SCAFFOLDING_HAP1:JUICER_PRE' {
+    withName: '.*SCAFFOLDING_HAP.*:JUICER_PRE' {
         ext.args2 = "LC_ALL=C sort -k2,2d -k6,6d -S50G | awk '\$3>=0 && \$7>=0'"
         publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-
-    // End of hap1 scaffolding
-
-    // hap2 scaffolding
-
-    withName: '.*HIC_MAPPING_HAP2:SAMTOOLS_MARKDUP_HIC_MAPPING' {
-        ext.prefix  = { "${meta.id}_mkdup" }
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*HIC_MAPPING_HAP2:BAMTOBED_SORT' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-
-    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_STATS' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_FLAGSTAT' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*HIC_MAPPING_HAP2:CONVERT_STATS:SAMTOOLS_IDXSTATS' {
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*SCAFFOLDING_HAP2:YAHS' {
-        ext.prefix = 'hap2'
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-
-    }
-
-    withName: '.*SCAFFOLDING_HAP2:COOLER_CLOAD' {
-        // Positions in the input file are zero-based;
-        // chrom1 field number (one-based) is 2;
-        // pos1 field number (one-based) is 3;
-        // chrom2 field number (one-based) is 6;
-        // pos2 field number (one-based) is 7
-        ext.args = 'pairs -0 -c1 2 -p1 3 -c2 6 -p2 7'
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*SCAFFOLDING_HAP2:PRETEXTSNAPSHOT' {
-        // Make one plot containing all sequences
-        ext.args = '--sequences \"=full\"'
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*SCAFFOLDING_HAP2:JUICER_TOOLS_PRE' {
-        ext.juicer_tools_jar = 'juicer_tools.1.9.9_jcuda.0.8.jar'
-        ext.juicer_jvm_params = '-Xms1g -Xmx6g'
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
-    }
-
-    withName: '.*SCAFFOLDING_HAP2:JUICER_PRE' {
-        ext.args2 = "LC_ALL=C sort -k2,2d -k6,6d -S50G | awk '\$3>=0 && \$7>=0'"
-        publishDir = [
-            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs" },
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_${meta.hap_id}/yahs/out.break.yahs" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
     }
-    // End of hap2 scaffolding
+
+    // End of hap1/hap2 scaffolding
 
     withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:GFASTATS_PRI' {
         ext.prefix = { "${meta.id}_scaffolds_final" }
@@ -910,7 +810,6 @@ process {
 
     // End of Scaffolding hap1/hap2
     // End of Set up of the scaffolding  pipeline
-
 
     //Set up of assembly stats subworkflow
     withName: 'BUSCO' {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -655,7 +655,7 @@ process {
         ]
     }
 
-    // Scaffolding hap1/hap2 
+    // Scaffolding hap1/hap2
     if (params.hifiasm_hic_on) {
     // hap1 scaffolding
 
@@ -758,7 +758,7 @@ process {
     // End of hap1 scaffolding
 
     // hap2 scaffolding
-    
+
     withName: '.*HIC_MAPPING_HAP2:SAMTOOLS_MARKDUP_HIC_MAPPING' {
         ext.prefix  = { "${meta.id}_mkdup" }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -102,7 +102,7 @@ process {
         ]
     }
 
-    withName: '.*GENOME_STATISTICS_RAW:BUSCO' {
+    withName: '.*GENOME_STATISTICS_RAW:BUSCO_PRI' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasm}/${meta.id}.p_ctg.${meta.lineage}.busco" },
             mode: params.publish_dir_mode,
@@ -175,9 +175,22 @@ process {
             ]
         }
 
-        withName: '.*GENOME_STATISTICS_RAW_HIC:BUSCO' {
+        withName: '.*GENOME_STATISTICS_RAW_HIC:BUSCO_PRI' {
             publishDir = [
-                path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.p_ctg.${meta.lineage}.busco" },
+                path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.hap1.${meta.lineage}.busco" },
+                mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.endsWith('busco.log') ? filename :
+                        filename.endsWith('full_table.tsv') ? filename :
+                        filename.endsWith('missing_busco_list.tsv') ? filename :
+                        filename.startsWith('short_summary') ? filename :
+                        filename.endsWith('busco.batch_summary.txt') ? filename :
+                        null }
+            ]
+        }
+
+        withName: '.*GENOME_STATISTICS_RAW_HIC:BUSCO_HAP' {
+            publishDir = [
+                path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/${meta.id}.hap2.${meta.lineage}.busco" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.endsWith('busco.log') ? filename :
                         filename.endsWith('full_table.tsv') ? filename :
@@ -333,7 +346,7 @@ process {
         ]
     }
 
-    withName: '.*GENOME_STATISTICS_PURGED:BUSCO' {
+    withName: '.*GENOME_STATISTICS_PURGED:BUSCO_PRI' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasm}/purging/${meta.id}.purged.${meta.lineage}.busco" },
             mode: params.publish_dir_mode,
@@ -621,7 +634,7 @@ process {
         ]
     }
 
-    withName: '.*GENOME_STATISTICS_SCAFFOLDS:BUSCO' {
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS:BUSCO_PRI' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasm}/scaffolding/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
             mode: params.publish_dir_mode,
@@ -861,9 +874,22 @@ process {
         ]
     }
 
-    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:BUSCO' {
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:BUSCO_PRI' {
         publishDir = [
             path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap1/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.endsWith('busco.log') ? filename :
+                    filename.endsWith('full_table.tsv') ? filename :
+                    filename.endsWith('missing_busco_list.tsv') ? filename :
+                    filename.startsWith('short_summary') ? filename :
+                    filename.endsWith('busco.batch_summary.txt') ? filename :
+                    null }
+        ]
+    }
+
+    withName: '.*GENOME_STATISTICS_SCAFFOLDS_HAPS:BUSCO_HAP' {
+        publishDir = [
+            path: { "${params.outdir}/${meta.id}.${params.hifiasmhic}/scaffolding_hap2/yahs/out.break.yahs/out_scaffolds_final.${meta.lineage}.busco" },
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.endsWith('busco.log') ? filename :
                     filename.endsWith('full_table.tsv') ? filename :

--- a/docs/output.md
+++ b/docs/output.md
@@ -4,7 +4,14 @@
 
 This document describes the output produced by the genomeassembly pipeline.
 
-The directories listed below will be created in the results directory after the pipeline has finished. All paths are relative to the top-level results directory.
+The standard assembly pipeline contains running <code>hifiasm</code> on the HiFi reads, purging the primary contigs with <code>purge_dups</code>, and scaffolding them up with <code>YaHS</code>.
+Optionally, if Illumina 10X data is provided, the purged contigs and haplotigs can be polished.
+
+In case of a diploid genome when HiFi and HiC data is coming from the same individual addtionally <code>hifiasm</code> can be run in HiC mode to produce a phased assembly. In that case the produced haplotypes are not purged but scaffolded up directly with <code>YaHS</code>.
+
+Optionally, the organelles assembly can be triggered. The mitochondrion and (if relevant) plastid sequences are produced using <code>MitoHiFi</code> and <code>OATK</code>. 
+
+The directories listed below will be created in the <code>--outdir</code> directory after the pipeline has finished. All paths are relative to the top-level <code>--outdir</code> directory.
 
 ## Subworkflows
 
@@ -43,13 +50,16 @@ This subworkflow generates a KMER database and coverage model used in [PURGE_DUP
     - primary assembly in GFA and FASTA format; for more details refer to [hifiasm output](https://hifiasm.readthedocs.io/en/latest/interpreting-output.html) 
   - <code>.\*hifiasm.\*/.*a_ctg.[g]fa</code>
     - haplotigs in GFA and FASTA format; for more details refer to [hifiasm output](https://hifiasm.readthedocs.io/en/latest/interpreting-output.html)
+  - <code>.\*hifiasm-hic.\*/.*hap1.p_ctg.[g]fa</code>
+    - fully phased hap1 if hifiasm is run in HiC mode; for more details refer to [hifiasm output](https://hifiasm.readthedocs.io/en/latest/interpreting-output.html) 
+  - <code>.\*hifiasm-hic.\*/.*hap2.p_ctg.[g]fa</code>
+    - fully phased hap2 if hifiasm is run in HiC mode; for more details refer to [hifiasm output](https://hifiasm.readthedocs.io/en/latest/interpreting-output.html)
   - <code>.\*hifiasm.\*/.*bin</code>
     - internal binary hifiasm files; for more details refer [here](https://hifiasm.readthedocs.io/en/latest/faq.html#id12)
   
 </details>
 
 This subworkflow generates a raw assembly(-ies). First, hifiasm is run on the input HiFi reads then raw contigs are converted from GFA into FASTA format, this assembly is due to purging, polishing (optional) and scaffolding further down the pipeline.
-In case hifiasm HiC mode is switched on, it is performed as an extra step with results stored in hifiasm-hic folder.</p>
 
 ![Raw assembly subworkflow](images/v1/raw_assembly.png)
 
@@ -68,6 +78,7 @@ In case hifiasm HiC mode is switched on, it is performed as an extra step with r
 
 Retained haplotype is identified in primary assembly. The alternate contigs are updated correspondingly.
 The subworkflow relies on kmer coverage model to identify coverage thresholds. For more details see [purge_dups](https://github.com/dfguan/purge_dups)
+The two haplotype assemblies produced by hifiasm in HiC mode are not purged.
 
 </p>
 
@@ -98,9 +109,9 @@ This subworkflow uses read mapping of the Illumina 10X short read data to fix sh
 <details markdown="1">
   <summary>Output files</summary>
   
-  - <code>\*.hifiasm..\*/scaffolding/.*_merged_sorted.bed</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/.*_merged_sorted.bed</code>
     - bed file obtained from merged mkdup bam
-  - <code>\*.hifiasm..\*/scaffolding/.*mkdup.bam</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/.*mkdup.bam</code>
     - final read mapping bam with mapped reads  
 </details>
 
@@ -113,11 +124,11 @@ This subworkflow implements alignment of the Illumina HiC short reads to the pri
 <details markdown="1">
   <summary>Output files</summary>
   
-  - <code>\*.hifiasm..\*/scaffolding/.*.stats</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/.*.stats</code>
     - output of samtools stats 
-  - <code>\*.hifiasm..\*/scaffolding/.*.idxstats</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/.*.idxstats</code>
     - output of samtools idxstats
-  - <code>\*.hifiasm..\*/scaffolding/.*.flagstat</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/.*.flagstat</code>
     - output of samtools flagstat  
 </details>
 
@@ -128,17 +139,17 @@ This subworkflow produces statistcs for a bam file containing read mapping. It i
 <details markdown="1">
   <summary>Output files</summary>
   
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/out_scaffolds_final.fa</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/out_scaffolds_final.fa</code>
     - scaffolds in FASTA format
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/out_scaffolds_final.agp</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/out_scaffolds_final.agp</code>
     - coordinates of contigs relative to scaffolds
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/alignments_sorted.txt</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/alignments_sorted.txt</code>
     - Alignments for Juicer in text format
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/yahs_scaffolds.hic</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/yahs_scaffolds.hic</code>
     - Juicer HiC map
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/*cool</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/*cool</code>
     - HiC map for cooler
-  - <code>\*.hifiasm..\*/scaffolding/yahs/out.break.yahs/*.FullMap.png</code>
+  - <code>\*.hifiasm.\*/scaffolding[_hap1/_hap2/^$]/yahs/out.break.yahs/*.FullMap.png</code>
     - Pretext snapshot
 
 </details>

--- a/docs/output.md
+++ b/docs/output.md
@@ -7,7 +7,7 @@ This document describes the output produced by the genomeassembly pipeline.
 The standard assembly pipeline contains running <code>hifiasm</code> on the HiFi reads, purging the primary contigs with <code>purge_dups</code>, and scaffolding them up with <code>YaHS</code>.
 Optionally, if Illumina 10X data is provided, the purged contigs and haplotigs can be polished.
 
-In case of a diploid genome when HiFi and HiC data is coming from the same individual addtionally <code>hifiasm</code> can be run in HiC mode to produce a phased assembly. In that case the produced haplotypes are not purged but scaffolded up directly with <code>YaHS</code>.
+In case of a diploid genome when HiFi and HiC data come from the same individual an additional hifiasm run in HiC mode produces two balanced fully phased haplotypes. The haplotypes are not purged but scaffolded up directly with <code>YaHS</code>.
 
 Optionally, the organelles assembly can be triggered. The mitochondrion and (if relevant) plastid sequences are produced using <code>MitoHiFi</code> and <code>OATK</code>.
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -9,7 +9,7 @@ Optionally, if Illumina 10X data is provided, the purged contigs and haplotigs c
 
 In case of a diploid genome when HiFi and HiC data is coming from the same individual addtionally <code>hifiasm</code> can be run in HiC mode to produce a phased assembly. In that case the produced haplotypes are not purged but scaffolded up directly with <code>YaHS</code>.
 
-Optionally, the organelles assembly can be triggered. The mitochondrion and (if relevant) plastid sequences are produced using <code>MitoHiFi</code> and <code>OATK</code>. 
+Optionally, the organelles assembly can be triggered. The mitochondrion and (if relevant) plastid sequences are produced using <code>MitoHiFi</code> and <code>OATK</code>.
 
 The directories listed below will be created in the <code>--outdir</code> directory after the pipeline has finished. All paths are relative to the top-level <code>--outdir</code> directory.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,20 +59,27 @@ Example is based on [test.yaml](../assets/test.yaml).
 dataset:
   id: baUndUnlc1
   illumina_10X:
-    reads: /lustre/scratch123/tol/resources/nextflow/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/10x/
+    reads:
+      - https://tolit.cog.sanger.ac.uk/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/10x/baUndUnlc1_S12_L002_R1_001.fastq.gz
+      - https://tolit.cog.sanger.ac.uk/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/10x/baUndUnlc1_S12_L002_R2_001.fastq.gz
+      - https://tolit.cog.sanger.ac.uk/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/10x/baUndUnlc1_S12_L002_I1_001.fastq.gz
   pacbio:
     reads:
-      - reads: /lustre/scratch123/tol/resources/nextflow/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/pacbio/fasta/HiFi.reads.fasta
+      - reads: https://tolit.cog.sanger.ac.uk/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/pacbio/fasta/HiFi.reads.fasta
   HiC:
     reads:
-      - reads: /lustre/scratch123/tol/resources/nextflow/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/hic-arima2/41741_2#7.sub.cram
+      - reads: https://tolit.cog.sanger.ac.uk/test-data/Undibacterium_unclassified/genomic_data/baUndUnlc1/hic-arima2/41741_2%237.sub.cram
 hic_motif: GATC,GANTC,CTNAG,TTAA
+hic_aligner: bwamem2
 busco:
   lineage: bacteria_odb10
 mito:
   species: Caradrina clavipalpis
   min_length: 15000
   code: 5
+  fam: https://github.com/c-zhou/OatkDB/raw/main/v20230921/insecta_mito.fam
+plastid:
+  fam: https://github.com/c-zhou/OatkDB/raw/main/v20230921/acrogymnospermae_pltd.fam
 ```
 </details>
 

--- a/modules.json
+++ b/modules.json
@@ -8,247 +8,341 @@
                     "bcftools/concat": {
                         "branch": "master",
                         "git_sha": "582ff1755bdd205c65e2ba4c31e0a008dae299ec",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/consensus": {
                         "branch": "master",
                         "git_sha": "fa12afdf5874c1d11e4a20efe81c97935e8eea24",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/norm": {
                         "branch": "master",
                         "git_sha": "0435e4eebc94e53721c194b2d5d06f455a79e407",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/sort": {
                         "branch": "master",
                         "git_sha": "4a21e4cca35e72ec059abd67f790e0b192ce5d81",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/bedtools/bamtobed/bedtools-bamtobed.diff"
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "bfed129da5134b4439b1821c917972570d44d39c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "76cc4938c1f6ea5c7d83fed1eeffc146787f9543",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastk/histex": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "freebayes": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/freebayes/freebayes.diff"
                     },
                     "gatk4/mergevcfs": {
                         "branch": "master",
                         "git_sha": "643756685546fa61f5c8fba439af746c090b9180",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "genescopefk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gfastats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/gfastats/gfastats.diff"
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hifiasm": {
                         "branch": "master",
                         "git_sha": "aecb06fcdb995ff3e3df7c7a1fd119367d6d1996",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/hifiasm/hifiasm.diff"
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "72e277acfd9e61a9f1368eafb4a9e83f5bcaa9f5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "mitohifi/findmitoreference": {
                         "branch": "master",
                         "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff"
                     },
                     "mitohifi/mitohifi": {
                         "branch": "master",
                         "git_sha": "c607e74f7aa72eb7cb7cc0a1454f97d3907e8d84",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff"
                     },
                     "oatk": {
                         "branch": "master",
                         "git_sha": "d6a146325058eb9a18da2e898a2376e1d1093052",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "purgedups/calcuts": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/purgedups/calcuts/purgedups-calcuts.diff"
                     },
                     "purgedups/getseqs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/pbcstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/purgedups": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/splitfa": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/collate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "fd742419940e01ba1c5ecb172c3e32ec840662fe",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/fixmate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/markdup": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/merge": {
                         "branch": "master",
                         "git_sha": "0460d316170f75f323111b4a2c0a2989f0c32013",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "seqtk/subseq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/seqtk/subseq/seqtk-subseq.diff"
                     },
                     "yahs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,341 +8,247 @@
                     "bcftools/concat": {
                         "branch": "master",
                         "git_sha": "582ff1755bdd205c65e2ba4c31e0a008dae299ec",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/consensus": {
                         "branch": "master",
                         "git_sha": "fa12afdf5874c1d11e4a20efe81c97935e8eea24",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/norm": {
                         "branch": "master",
                         "git_sha": "0435e4eebc94e53721c194b2d5d06f455a79e407",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/sort": {
                         "branch": "master",
                         "git_sha": "4a21e4cca35e72ec059abd67f790e0b192ce5d81",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/bedtools/bamtobed/bedtools-bamtobed.diff"
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "bfed129da5134b4439b1821c917972570d44d39c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "76cc4938c1f6ea5c7d83fed1eeffc146787f9543",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastk/histex": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "freebayes": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/freebayes/freebayes.diff"
                     },
                     "gatk4/mergevcfs": {
                         "branch": "master",
                         "git_sha": "643756685546fa61f5c8fba439af746c090b9180",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "genescopefk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gfastats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/gfastats/gfastats.diff"
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "hifiasm": {
                         "branch": "master",
                         "git_sha": "aecb06fcdb995ff3e3df7c7a1fd119367d6d1996",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/hifiasm/hifiasm.diff"
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "72e277acfd9e61a9f1368eafb4a9e83f5bcaa9f5",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "mitohifi/findmitoreference": {
                         "branch": "master",
                         "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff"
                     },
                     "mitohifi/mitohifi": {
                         "branch": "master",
                         "git_sha": "c607e74f7aa72eb7cb7cc0a1454f97d3907e8d84",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff"
                     },
                     "oatk": {
                         "branch": "master",
                         "git_sha": "d6a146325058eb9a18da2e898a2376e1d1093052",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "purgedups/calcuts": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/purgedups/calcuts/purgedups-calcuts.diff"
                     },
                     "purgedups/getseqs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/pbcstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/purgedups": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/splitfa": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/collate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "fd742419940e01ba1c5ecb172c3e32ec840662fe",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/fixmate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/markdup": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/merge": {
                         "branch": "master",
                         "git_sha": "0460d316170f75f323111b4a2c0a2989f0c32013",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "seqtk/subseq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/seqtk/subseq/seqtk-subseq.diff"
                     },
                     "yahs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             }

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -1,0 +1,8 @@
+name: hifiasm
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::hifiasm=0.19.8
+  - bioconda::samtools=1.20

--- a/modules/nf-core/hifiasm/hifiasm.diff
+++ b/modules/nf-core/hifiasm/hifiasm.diff
@@ -13,7 +13,7 @@ Changes in module 'nf-core/hifiasm'
 +        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
 +    }
 +
-+    container "wave.seqera.io/wt/73ac3caec075/wave/build:hifiasm-0.19.8_samtools-1.20--1f6824530f0d0ad5"
++    container "quay.io/sanger-tol/hifiasm_samtools:0.01"
  
      input:
      tuple val(meta), path(reads)
@@ -25,12 +25,14 @@ Changes in module 'nf-core/hifiasm'
  
      output:
      tuple val(meta), path("*.r_utg.gfa")       , emit: raw_unitigs
-@@ -23,8 +25,10 @@
+@@ -23,8 +25,12 @@
      tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
      tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
      tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
 -    tuple val(meta), path("*.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true
 -    tuple val(meta), path("*.hap2.p_ctg.gfa")  , emit: maternal_contigs , optional: true
++    tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")   , emit: hap1_contigs  , optional: true
++    tuple val(meta), path("*.asm.hic.hap2.p_ctg.gfa")   , emit: hap2_contigs  , optional: true
 +    tuple val(meta), path("*.asm.hic.p_ctg.gfa")   , emit: hic_primary_contigs  , optional: true
 +    tuple val(meta), path("*.asm.hic.a_ctg.gfa")   , emit: hic_alternate_contigs  , optional: true
 +    tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true
@@ -38,7 +40,7 @@ Changes in module 'nf-core/hifiasm'
      tuple val(meta), path("*.log")             , emit: log
      path  "versions.yml"                       , emit: versions
  
-@@ -34,6 +38,8 @@
+@@ -34,6 +40,8 @@
      script:
      def args = task.ext.args ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
@@ -47,7 +49,7 @@ Changes in module 'nf-core/hifiasm'
      if ((paternal_kmer_dump) && (maternal_kmer_dump) && (hic_read1) && (hic_read2)) {
          error "Hifiasm Trio-binning and Hi-C integrated should not be used at the same time"
      } else if ((paternal_kmer_dump) && !(maternal_kmer_dump)) {
-@@ -67,8 +73,8 @@
+@@ -67,8 +75,8 @@
              $args \\
              -o ${prefix}.asm \\
              -t $task.cpus \\
@@ -58,5 +60,16 @@ Changes in module 'nf-core/hifiasm'
              $reads \\
              2> >( tee ${prefix}.stderr.log >&2 )
  
+
+--- modules/nf-core/hifiasm/environment.yml
++++ /dev/null
+@@ -1,7 +0,0 @@
+-name: hifiasm
+-channels:
+-  - conda-forge
+-  - bioconda
+-  - defaults
+-dependencies:
+-  - bioconda::hifiasm=0.19.8
 
 ************************************************************

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -25,6 +25,8 @@ process HIFIASM {
     tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
     tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
     tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
+    tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")   , emit: hap1_contigs  , optional: true
+    tuple val(meta), path("*.asm.hic.hap2.p_ctg.gfa")   , emit: hap2_contigs  , optional: true
     tuple val(meta), path("*.asm.hic.p_ctg.gfa")   , emit: hic_primary_contigs  , optional: true
     tuple val(meta), path("*.asm.hic.a_ctg.gfa")   , emit: hic_alternate_contigs  , optional: true
     tuple val(meta), path("*.asm.hic.hap1.p_ctg.gfa")  , emit: paternal_contigs , optional: true

--- a/subworkflows/local/hic_bwamem2.nf
+++ b/subworkflows/local/hic_bwamem2.nf
@@ -35,18 +35,17 @@ workflow HIC_BWAMEM2 {
                     id: cram_id.id
                     ],
                 file(cram_info[0]),
-                cram_info[1],
-                cram_info[2],
-                cram_info[3],
-                cram_info[4],
-                cram_info[5],
-                cram_info[6],
-                bwa_path.toString() + '/' + ref_dir.toString().split('/')[-1],
-                ref_dir
+                cram_info[1], // crai path
+                cram_info[2], // chunk starting position
+                cram_info[3], // chunk end position 
+                cram_info[4], // basename 
+                cram_info[5], // the number of chunk
+                cram_info[6], // rgline
+                bwa_path.toString() + '/' + ref_dir.toString().split('/')[-1]
             )
     }
     .set { ch_filtering_input }
-    ch_filtering_input.view()
+
     //
     // MODULE: map hic reads by 10,000 container per time using bwamem2
     //

--- a/subworkflows/local/hic_bwamem2.nf
+++ b/subworkflows/local/hic_bwamem2.nf
@@ -68,7 +68,7 @@ workflow HIC_BWAMEM2 {
         .map { file ->
             tuple (
                 [
-                id: file[0].toString().split('/')[-1].split('_')[0] + '_' + file[0].toString().split('/')[-1].split('_')[1]
+                id: file[0].toString().split('/')[-1].split('_')[0] 
                 ],
                 file
             )

--- a/subworkflows/local/hic_mapping.nf
+++ b/subworkflows/local/hic_mapping.nf
@@ -26,6 +26,7 @@ workflow HIC_MAPPING {
     reference_tuple     // Channel [ val(meta), path(file) ]
     hic_reads_path      // Channel [ val(meta), path(directory) ]
     hic_aligner_ch      // Channel [ val(meta), val(hic_aligner)]
+    hap_id              // Value hap_id
 
     main:
     ch_versions = Channel.empty()
@@ -67,7 +68,8 @@ workflow HIC_MAPPING {
             bwamem2       : it[0].aligner == "bwamem2"
         }
         .set{ch_aligner}
-    
+
+      
     //
     // SUBWORKFLOW: mapping hic reads using minimap2
     //
@@ -78,7 +80,7 @@ workflow HIC_MAPPING {
     ch_versions         = ch_versions.mix( HIC_MINIMAP2.out.versions )
     mappedbams           = HIC_MINIMAP2.out.mappedbams
     
-        //
+    //
     // SUBWORKFLOW: mapping hic reads using bwamem2
     //
     HIC_BWAMEM2 (
@@ -87,6 +89,9 @@ workflow HIC_MAPPING {
     )
     ch_versions         = ch_versions.mix( HIC_BWAMEM2.out.versions )
     mappedbams           = mappedbams.mix(HIC_BWAMEM2.out.mappedbams)
+
+    mappedbams.map{meta, bams -> [[id: meta.id, hap_id:hap_id], bams]}
+              .set { mappedbams }
 
     //
     // LOGIC: GENERATE INDEX OF REFERENCE

--- a/subworkflows/local/hic_mapping.nf
+++ b/subworkflows/local/hic_mapping.nf
@@ -43,7 +43,7 @@ workflow HIC_MAPPING {
     reference_tuple
         .join( hic_reads_path )
         .map { meta, ref, hic_reads_path ->
-                tuple([ id: meta.id, single_end: true], hic_reads_path, hic_reads_path.collect { p -> p.resolveSibling(p.name + ".crai") } ) }
+                tuple([ id: meta.id, hap_id: hap_id, single_end: true], hic_reads_path, hic_reads_path.collect { p -> p.resolveSibling(p.name + ".crai") } ) }
         .set { get_reads_input }
 
     //

--- a/subworkflows/local/hic_minimap2.nf
+++ b/subworkflows/local/hic_minimap2.nf
@@ -43,12 +43,12 @@ workflow HIC_MINIMAP2 {
                     id: cram_id.id
                     ],
                 file(cram_info[0]),
-                cram_info[1],
-                cram_info[2],
-                cram_info[3],
-                cram_info[4],
-                cram_info[5],
-                cram_info[6],
+                cram_info[1], // crai path
+                cram_info[2], // chunk starting position
+                cram_info[3], // chunk end position 
+                cram_info[4], // basename 
+                cram_info[5], // the number of chunk
+                cram_info[6], // rgline
                 mmi_path.toString(),
                 ref_dir
             )

--- a/subworkflows/local/hic_minimap2.nf
+++ b/subworkflows/local/hic_minimap2.nf
@@ -77,7 +77,7 @@ workflow HIC_MINIMAP2 {
         .map { file ->
             tuple (
                 [
-                id: file[0].toString().split('/')[-1].split('_')[0] + '_' + file[0].toString().split('/')[-1].split('_')[1]
+                id: file[0].toString().split('/')[-1].split('_')[0]
                 ],
                 file
             )

--- a/subworkflows/local/raw_assembly.nf
+++ b/subworkflows/local/raw_assembly.nf
@@ -3,8 +3,8 @@ include { HIFIASM as HIFIASM_HIC                } from '../../modules/nf-core/hi
 
 include { GFA_TO_FASTA as GFA_TO_FASTA_PRI      } from '../../modules/local/gfa_to_fasta'
 include { GFA_TO_FASTA as GFA_TO_FASTA_ALT      } from '../../modules/local/gfa_to_fasta'
-include { GFA_TO_FASTA as GFA_TO_FASTA_PRI_HIC  } from '../../modules/local/gfa_to_fasta'
-include { GFA_TO_FASTA as GFA_TO_FASTA_ALT_HIC  } from '../../modules/local/gfa_to_fasta'
+include { GFA_TO_FASTA as GFA_TO_FASTA_HAP1_HIC  } from '../../modules/local/gfa_to_fasta'
+include { GFA_TO_FASTA as GFA_TO_FASTA_HAP2_HIC  } from '../../modules/local/gfa_to_fasta'
 
 workflow RAW_ASSEMBLY {
     take:
@@ -44,19 +44,19 @@ workflow RAW_ASSEMBLY {
         //
         // MODULE: CONVERT HIFIASM-HIC PRIMARY CONTIGS TO FASTA
         //
-        GFA_TO_FASTA_PRI_HIC( HIFIASM_HIC.out.hic_primary_contigs )
+        GFA_TO_FASTA_HAP1_HIC( HIFIASM_HIC.out.hap1_contigs )
         
         //
         // MODULE: CONVERT HIFIASM-HIC ALT CONTIGS TO FASTA
         //
-        GFA_TO_FASTA_ALT_HIC( HIFIASM_HIC.out.hic_alternate_contigs )
+        GFA_TO_FASTA_HAP2_HIC( HIFIASM_HIC.out.hap2_contigs )
     }
 
     emit:
     primary_contigs = GFA_TO_FASTA_PRI.out.fasta
     alternate_contigs = GFA_TO_FASTA_ALT.out.fasta
-    primary_hic_contigs = hifiasm_hic_on ? GFA_TO_FASTA_PRI_HIC.out.fasta : null
-    alternate_hic_contigs = hifiasm_hic_on ? GFA_TO_FASTA_ALT_HIC.out.fasta : null
+    hap1_hic_contigs = hifiasm_hic_on ? GFA_TO_FASTA_HAP1_HIC.out.fasta : null
+    hap2_hic_contigs = hifiasm_hic_on ? GFA_TO_FASTA_HAP2_HIC.out.fasta : null
 
     versions = ch_versions
 }

--- a/workflows/genomeassembly.nf
+++ b/workflows/genomeassembly.nf
@@ -122,12 +122,19 @@ workflow GENOMEASSEMBLY {
     RAW_ASSEMBLY.out.alternate_contigs.set{ haplotigs_ch }
 
     //
+    // LOGIC: DECLARE CONSTANTS TO TOGGLE BUSCO FOR ALTS
+    //
+    set_busco_alts = true
+    unset_busco_alts = false
+    
+    //
     // SUBWORKFLOW: CALCULATE STATISTICS FOR THE RAW ASSEMBLY
     //
     GENOME_STATISTICS_RAW( primary_contigs_ch.join(haplotigs_ch), 
                        PREPARE_INPUT.out.busco,
                        GENOMESCOPE_MODEL.out.hist,
-                       GENOMESCOPE_MODEL.out.ktab
+                       GENOMESCOPE_MODEL.out.ktab,
+                       unset_busco_alts
     )
     ch_versions = ch_versions.mix(GENOME_STATISTICS_RAW.out.versions)
 
@@ -173,7 +180,8 @@ workflow GENOMEASSEMBLY {
                                     .join(RAW_ASSEMBLY.out.hap2_hic_contigs), 
                            PREPARE_INPUT.out.busco,
                            GENOMESCOPE_MODEL.out.hist,
-                           GENOMESCOPE_MODEL.out.ktab
+                           GENOMESCOPE_MODEL.out.ktab,
+                           set_busco_alts
         )
     }
 
@@ -215,7 +223,8 @@ workflow GENOMEASSEMBLY {
     GENOME_STATISTICS_PURGED( primary_contigs_ch.join(haplotigs_ch), 
                        PREPARE_INPUT.out.busco,
                        GENOMESCOPE_MODEL.out.hist,
-                       GENOMESCOPE_MODEL.out.ktab
+                       GENOMESCOPE_MODEL.out.ktab,
+                       unset_busco_alts
     )
    
     //
@@ -315,7 +324,8 @@ workflow GENOMEASSEMBLY {
         GENOME_STATISTICS_POLISHED( polished_asm_stats_input_ch, 
                        PREPARE_INPUT.out.busco,
                        GENOMESCOPE_MODEL.out.hist,
-                       GENOMESCOPE_MODEL.out.ktab
+                       GENOMESCOPE_MODEL.out.ktab,
+                       unset_busco_alts
         )
     }
 
@@ -354,7 +364,8 @@ workflow GENOMEASSEMBLY {
     GENOME_STATISTICS_SCAFFOLDS( stats_input_ch, 
                        PREPARE_INPUT.out.busco,
                        GENOMESCOPE_MODEL.out.hist,
-                       GENOMESCOPE_MODEL.out.ktab
+                       GENOMESCOPE_MODEL.out.ktab,
+                       unset_busco_alts
     )
 
 
@@ -396,7 +407,8 @@ workflow GENOMEASSEMBLY {
         GENOME_STATISTICS_SCAFFOLDS_HAPS( stats_haps_input_ch, 
                        PREPARE_INPUT.out.busco,
                        GENOMESCOPE_MODEL.out.hist,
-                       GENOMESCOPE_MODEL.out.ktab
+                       GENOMESCOPE_MODEL.out.ktab,
+                       set_busco_alts
     )
 
     }

--- a/workflows/genomeassembly.nf
+++ b/workflows/genomeassembly.nf
@@ -340,13 +340,13 @@ workflow GENOMEASSEMBLY {
     //
     // SUBWORKFLOW: MAP HIC DATA TO THE PRIMARY ASSEMBLY
     //
-    HIC_MAPPING ( primary_contigs_ch,crams_ch,hic_aligner_ch )
+    HIC_MAPPING ( primary_contigs_ch,crams_ch,hic_aligner_ch, "")
     ch_versions = ch_versions.mix(HIC_MAPPING.out.versions)
 
     //
     // SUBWORKFLOW: SCAFFOLD THE PRIMARY ASSEMBLY
     //
-    SCAFFOLDING( HIC_MAPPING.out.bed, primary_contigs_ch, cool_bin )
+    SCAFFOLDING( HIC_MAPPING.out.bed, primary_contigs_ch, cool_bin, "")
     ch_versions = ch_versions.mix(SCAFFOLDING.out.versions)
 
     //
@@ -367,37 +367,36 @@ workflow GENOMEASSEMBLY {
                        unset_busco_alts
     )
 
-
     if ( hifiasm_hic_on ) {
         //
         // SUBWORKFLOW: MAP HIC DATA TO THE HAP1 CONTIGS
         //
-        HIC_MAPPING_HAP1 ( RAW_ASSEMBLY.out.hap1_hic_contigs, crams_ch, hic_aligner_ch )
+        HIC_MAPPING_HAP1 ( RAW_ASSEMBLY.out.hap1_hic_contigs, crams_ch, hic_aligner_ch, 'hap1' )
         ch_versions = ch_versions.mix(HIC_MAPPING_HAP1.out.versions)
 
         //
         // SUBWORKFLOW: SCAFFOLD HAP1
         //
-        SCAFFOLDING_HAP1( HIC_MAPPING_HAP1.out.bed, RAW_ASSEMBLY.out.hap1_hic_contigs, cool_bin )
+        SCAFFOLDING_HAP1( HIC_MAPPING_HAP1.out.bed, RAW_ASSEMBLY.out.hap1_hic_contigs, cool_bin, 'hap1' )
         ch_versions = ch_versions.mix(SCAFFOLDING_HAP1.out.versions)
 
         //
         // SUBWORKFLOW: MAP HIC DATA TO THE HAP2 CONTIGS
         //
-        HIC_MAPPING_HAP2 ( RAW_ASSEMBLY.out.hap2_hic_contigs, crams_ch, hic_aligner_ch )
+        HIC_MAPPING_HAP2 ( RAW_ASSEMBLY.out.hap2_hic_contigs, crams_ch, hic_aligner_ch, 'hap2' )
         ch_versions = ch_versions.mix(HIC_MAPPING_HAP2.out.versions)
         
         //
         // SUBWORKFLOW: SCAFFOLD HAP2
         //
-        SCAFFOLDING_HAP2( HIC_MAPPING_HAP2.out.bed, RAW_ASSEMBLY.out.hap2_hic_contigs, cool_bin )
+        SCAFFOLDING_HAP2( HIC_MAPPING_HAP2.out.bed, RAW_ASSEMBLY.out.hap2_hic_contigs, cool_bin, 'hap2' )
         ch_versions = ch_versions.mix(SCAFFOLDING_HAP2.out.versions)
         
         //
         // LOGIC: CREATE A CHANNEL FOR THE FULL HAP1/HAP2 ASSEMBLY
         //
         SCAFFOLDING_HAP1.out.fasta.combine(SCAFFOLDING_HAP2.out.fasta)
-                    .map{meta_s, fasta_s, meta_h, fasta_h -> [ meta_h, fasta_s, fasta_h ]}
+                    .map{meta_s, fasta_s, meta_h, fasta_h -> [ [id:meta_h.id], fasta_s, fasta_h ]}
                     .set{ stats_haps_input_ch }
     
         //

--- a/workflows/genomeassembly.nf
+++ b/workflows/genomeassembly.nf
@@ -20,6 +20,11 @@ if (params.cool_bin) { cool_bin = params.cool_bin } else { cool_bin = 1000; }
 if (params.polishing_on) { polishing_on = params.polishing_on } else { polishing_on = false; }
 if (params.hifiasm_hic_on) { hifiasm_hic_on = params.hifiasm_hic_on } else { hifiasm_hic_on = false; }
 if (params.organelles_on) { organelles_on = params.organelles_on } else { organelles_on = false; }
+
+// Declare constants to toggle BUSCO for alts
+set_busco_alts = true
+unset_busco_alts = false
+
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     CONFIG FILES
@@ -121,12 +126,6 @@ workflow GENOMEASSEMBLY {
     //
     RAW_ASSEMBLY.out.alternate_contigs.set{ haplotigs_ch }
 
-    //
-    // LOGIC: DECLARE CONSTANTS TO TOGGLE BUSCO FOR ALTS
-    //
-    set_busco_alts = true
-    unset_busco_alts = false
-    
     //
     // SUBWORKFLOW: CALCULATE STATISTICS FOR THE RAW ASSEMBLY
     //


### PR DESCRIPTION
Implements https://jira.sanger.ac.uk/browse/TOLA-315

When hifiasm in hic mode is switched on hap1/hap2 contigs are scaffolded up.
Before this PR was implemented the phased assemblies were only contig-level. Now the phased hifiasm contigs are scaffolded up and usual QC checks are run for them.

<!--
# sanger-tol/genomeassembly pull request

Many thanks for contributing to sanger-tol/genomeassembly!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
