### PR TITLE
Remove defaults channel from remaining modules

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-node@v3
 
       - name: Install editorconfig-checker
-        run: npm install -g editorconfig-checker
+        run: npm install -g editorconfig-checker@3.0.2
 
       - name: Run ECLint check
         run: editorconfig-checker -exclude README.md $(find .* -type f | grep -v '.git\|.py\|.md\|cff\|json\|yml\|yaml\|html\|css\|work\|.nextflow\|build\|nf_core.egg-info\|log.txt\|Makefile\|drawio')
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload linting log file artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linting-logs
           path: |

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -215,6 +215,10 @@ process {
     // Set up of organelles pipeline
 
     if (params.organelles_on) {
+        withName: 'MITOHIFI_FINDMITOREFERENCE' {
+            ext.args = { "--min_length ${meta.min_length}" }
+        }
+
         withName: '.*MITOHIFI_MITOHIFI_READS' {
             ext.args2 = '-r'
             publishDir = [

--- a/lib/Utils.groovy
+++ b/lib/Utils.groovy
@@ -22,7 +22,7 @@ class Utils {
 
         // Check that all channels are present
         // This channel list is ordered by required channel priority.
-        def required_channels_in_order = ['conda-forge', 'bioconda', 'defaults']
+        def required_channels_in_order = ['conda-forge', 'bioconda']
         def channels_missing = ((required_channels_in_order as Set) - (channels as Set)) as Boolean
 
         // Check that they are in the right order

--- a/modules.json
+++ b/modules.json
@@ -133,13 +133,13 @@
                     },
                     "mitohifi/findmitoreference": {
                         "branch": "master",
-                        "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
+                        "git_sha": "45bd069e0d8fc926d8d40d5da81489e70f03aac2",
                         "installed_by": ["modules"],
                         "patch": "modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff"
                     },
                     "mitohifi/mitohifi": {
                         "branch": "master",
-                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "git_sha": "45bd069e0d8fc926d8d40d5da81489e70f03aac2",
                         "installed_by": ["modules"]
                     },
                     "oatk": {

--- a/modules.json
+++ b/modules.json
@@ -8,341 +8,247 @@
                     "bcftools/concat": {
                         "branch": "master",
                         "git_sha": "582ff1755bdd205c65e2ba4c31e0a008dae299ec",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/consensus": {
                         "branch": "master",
                         "git_sha": "fa12afdf5874c1d11e4a20efe81c97935e8eea24",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/norm": {
                         "branch": "master",
                         "git_sha": "0435e4eebc94e53721c194b2d5d06f455a79e407",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/sort": {
                         "branch": "master",
                         "git_sha": "4a21e4cca35e72ec059abd67f790e0b192ce5d81",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bcftools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/bedtools/bamtobed/bedtools-bamtobed.diff"
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "bfed129da5134b4439b1821c917972570d44d39c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "76cc4938c1f6ea5c7d83fed1eeffc146787f9543",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastk/histex": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "freebayes": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/freebayes/freebayes.diff"
                     },
                     "gatk4/mergevcfs": {
                         "branch": "master",
                         "git_sha": "643756685546fa61f5c8fba439af746c090b9180",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "genescopefk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gfastats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/gfastats/gfastats.diff"
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "hifiasm": {
                         "branch": "master",
                         "git_sha": "aecb06fcdb995ff3e3df7c7a1fd119367d6d1996",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/hifiasm/hifiasm.diff"
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "72e277acfd9e61a9f1368eafb4a9e83f5bcaa9f5",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/minimap2/index/minimap2-index.diff"
                     },
                     "mitohifi/findmitoreference": {
                         "branch": "master",
                         "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff"
                     },
                     "mitohifi/mitohifi": {
                         "branch": "master",
                         "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "oatk": {
                         "branch": "master",
                         "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "purgedups/calcuts": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/purgedups/calcuts/purgedups-calcuts.diff"
                     },
                     "purgedups/getseqs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/pbcstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/purgedups": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "purgedups/splitfa": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/collate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "fd742419940e01ba1c5ecb172c3e32ec840662fe",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/fixmate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/markdup": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/merge": {
                         "branch": "master",
                         "git_sha": "0460d316170f75f323111b4a2c0a2989f0c32013",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "seqtk/subseq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/seqtk/subseq/seqtk-subseq.diff"
                     },
                     "yahs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,247 +8,341 @@
                     "bcftools/concat": {
                         "branch": "master",
                         "git_sha": "582ff1755bdd205c65e2ba4c31e0a008dae299ec",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/consensus": {
                         "branch": "master",
                         "git_sha": "fa12afdf5874c1d11e4a20efe81c97935e8eea24",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/norm": {
                         "branch": "master",
                         "git_sha": "0435e4eebc94e53721c194b2d5d06f455a79e407",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/sort": {
                         "branch": "master",
                         "git_sha": "4a21e4cca35e72ec059abd67f790e0b192ce5d81",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bcftools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bedtools/bamtobed": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/bedtools/bamtobed/bedtools-bamtobed.diff"
                     },
                     "busco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bwamem2/index": {
                         "branch": "master",
                         "git_sha": "bfed129da5134b4439b1821c917972570d44d39c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/cat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/cload": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cooler/zoomify": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "76cc4938c1f6ea5c7d83fed1eeffc146787f9543",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastk/fastk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastk/histex": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "freebayes": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/freebayes/freebayes.diff"
                     },
                     "gatk4/mergevcfs": {
                         "branch": "master",
                         "git_sha": "643756685546fa61f5c8fba439af746c090b9180",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "genescopefk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gfastats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/gfastats/gfastats.diff"
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "hifiasm": {
                         "branch": "master",
                         "git_sha": "aecb06fcdb995ff3e3df7c7a1fd119367d6d1996",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/hifiasm/hifiasm.diff"
                     },
                     "merquryfk/merquryfk": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/minimap2/align/minimap2-align.diff"
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "72e277acfd9e61a9f1368eafb4a9e83f5bcaa9f5",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ],
+                        "patch": "modules/nf-core/minimap2/index/minimap2-index.diff"
                     },
                     "mitohifi/findmitoreference": {
                         "branch": "master",
                         "git_sha": "f52220e84bfc16a8616a5bb3d6f5bc67d601bdce",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff"
                     },
                     "mitohifi/mitohifi": {
                         "branch": "master",
-                        "git_sha": "c607e74f7aa72eb7cb7cc0a1454f97d3907e8d84",
-                        "installed_by": ["modules"],
-                        "patch": "modules/nf-core/mitohifi/mitohifi/mitohifi-mitohifi.diff"
+                        "git_sha": "666652151335353eef2fcd58880bcef5bc2928e1",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "oatk": {
                         "branch": "master",
-                        "git_sha": "d6a146325058eb9a18da2e898a2376e1d1093052",
-                        "installed_by": ["modules"]
+                        "git_sha": "81880787133db07d9b4c1febd152c090eb8325dc",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pretextmap": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "pretextsnapshot": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/pretextsnapshot/pretextsnapshot.diff"
                     },
                     "purgedups/calcuts": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/purgedups/calcuts/purgedups-calcuts.diff"
                     },
                     "purgedups/getseqs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/pbcstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/purgedups": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "purgedups/splitfa": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/collate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "fd742419940e01ba1c5ecb172c3e32ec840662fe",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/fixmate": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/flagstat": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/idxstats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/markdup": {
                         "branch": "master",
                         "git_sha": "9e51255c4f8ec69fb6ccf68593392835f14fecb8",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/merge": {
                         "branch": "master",
                         "git_sha": "0460d316170f75f323111b4a2c0a2989f0c32013",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/sort": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "seqtk/subseq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/seqtk/subseq/seqtk-subseq.diff"
                     },
                     "yahs": {
                         "branch": "master",
                         "git_sha": "0f8a77ff00e65eaeebc509b8156eaa983192474b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/hifiasm/environment.yml
+++ b/modules/nf-core/hifiasm/environment.yml
@@ -2,7 +2,6 @@ name: hifiasm
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::hifiasm=0.19.8
   - bioconda::samtools=1.20

--- a/modules/nf-core/hifiasm/hifiasm.diff
+++ b/modules/nf-core/hifiasm/hifiasm.diff
@@ -1,7 +1,21 @@
-Changes in module 'nf-core/hifiasm'
+Changes in component 'nf-core/hifiasm'
+Changes in 'hifiasm/environment.yml':
+--- modules/nf-core/hifiasm/environment.yml
++++ modules/nf-core/hifiasm/environment.yml
+@@ -2,6 +2,6 @@
+ channels:
+   - conda-forge
+   - bioconda
+-  - defaults
+ dependencies:
+   - bioconda::hifiasm=0.19.8
++  - bioconda::samtools=1.20
+
+'modules/nf-core/hifiasm/meta.yml' is unchanged
+Changes in 'hifiasm/main.nf':
 --- modules/nf-core/hifiasm/main.nf
 +++ modules/nf-core/hifiasm/main.nf
-@@ -2,10 +2,11 @@
+@@ -2,10 +2,7 @@
      tag "$meta.id"
      label 'process_high'
  
@@ -9,15 +23,11 @@ Changes in module 'nf-core/hifiasm'
 -    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
 -        'https://depot.galaxyproject.org/singularity/hifiasm:0.19.8--h43eeafb_0' :
 -        'biocontainers/hifiasm:0.19.8--h43eeafb_0' }"
-+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-+        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
-+    }
-+
 +    container "quay.io/sanger-tol/hifiasm_samtools:0.01"
  
      input:
      tuple val(meta), path(reads)
-@@ -13,6 +14,7 @@
+@@ -13,6 +10,7 @@
      path  maternal_kmer_dump
      path  hic_read1
      path  hic_read2
@@ -25,7 +35,7 @@ Changes in module 'nf-core/hifiasm'
  
      output:
      tuple val(meta), path("*.r_utg.gfa")       , emit: raw_unitigs
-@@ -23,8 +25,12 @@
+@@ -23,8 +21,12 @@
      tuple val(meta), path("*.p_utg.gfa")       , emit: processed_unitigs, optional: true
      tuple val(meta), path("*.asm.p_ctg.gfa")   , emit: primary_contigs  , optional: true
      tuple val(meta), path("*.asm.a_ctg.gfa")   , emit: alternate_contigs, optional: true
@@ -40,8 +50,14 @@ Changes in module 'nf-core/hifiasm'
      tuple val(meta), path("*.log")             , emit: log
      path  "versions.yml"                       , emit: versions
  
-@@ -34,6 +40,8 @@
+@@ -32,8 +34,14 @@
+     task.ext.when == null || task.ext.when
+ 
      script:
++    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
++        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
++    }
++    
      def args = task.ext.args ?: ''
      def prefix = task.ext.prefix ?: "${meta.id}"
 +    def hic_read1 = hic_reads_cram ? "for f in $hic_reads_cram; do samtools cat \$f | samtools fastq -n -f0x40 -F0xB00; done" : ""
@@ -60,16 +76,5 @@ Changes in module 'nf-core/hifiasm'
              $reads \\
              2> >( tee ${prefix}.stderr.log >&2 )
  
-
---- modules/nf-core/hifiasm/environment.yml
-+++ /dev/null
-@@ -1,7 +0,0 @@
--name: hifiasm
--channels:
--  - conda-forge
--  - bioconda
--  - defaults
--dependencies:
--  - bioconda::hifiasm=0.19.8
 
 ************************************************************

--- a/modules/nf-core/hifiasm/main.nf
+++ b/modules/nf-core/hifiasm/main.nf
@@ -2,10 +2,6 @@ process HIFIASM {
     tag "$meta.id"
     label 'process_high'
 
-    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
-    }
-
     container "quay.io/sanger-tol/hifiasm_samtools:0.01"
 
     input:
@@ -38,6 +34,10 @@ process HIFIASM {
     task.ext.when == null || task.ext.when
 
     script:
+    if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
+        exit 1, "This version of HIFIASM module does not support Conda. Please use Docker / Singularity / Podman instead."
+    }
+    
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def hic_read1 = hic_reads_cram ? "for f in $hic_reads_cram; do samtools cat \$f | samtools fastq -n -f0x40 -F0xB00; done" : ""

--- a/modules/nf-core/minimap2/index/environment.yml
+++ b/modules/nf-core/minimap2/index/environment.yml
@@ -2,6 +2,5 @@ name: minimap2_index
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
   - bioconda::minimap2=2.28

--- a/modules/nf-core/minimap2/index/minimap2-index.diff
+++ b/modules/nf-core/minimap2/index/minimap2-index.diff
@@ -1,0 +1,18 @@
+Changes in component 'nf-core/minimap2/index'
+Changes in 'minimap2/index/environment.yml':
+--- modules/nf-core/minimap2/index/environment.yml
++++ modules/nf-core/minimap2/index/environment.yml
+@@ -2,6 +2,5 @@
+ channels:
+   - conda-forge
+   - bioconda
+-  - defaults
+ dependencies:
+   - bioconda::minimap2=2.28
+
+'modules/nf-core/minimap2/index/meta.yml' is unchanged
+'modules/nf-core/minimap2/index/main.nf' is unchanged
+'modules/nf-core/minimap2/index/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/minimap2/index/tests/tags.yml' is unchanged
+'modules/nf-core/minimap2/index/tests/main.nf.test' is unchanged
+************************************************************

--- a/modules/nf-core/mitohifi/findmitoreference/meta.yml
+++ b/modules/nf-core/mitohifi/findmitoreference/meta.yml
@@ -12,33 +12,43 @@ tools:
       tool_dev_url: https://github.com/marcelauliano/MitoHiFi
       doi: "10.1101/2022.12.23.521667"
       licence: ["MIT"]
-
+      identifier: biotools:mitohifi
 input:
-  - species:
-      type: string
-      description: Latin name of the species for which a mitochondrial genome should be fetched
-      pattern: "[A-Z]?[a-z]* [a-z]*"
-  - email:
-      type: string
-      description: Email address for NCBI query
-  - min_length:
-      type: integer
-      description: Minimum length of the mitochondrial genome
-      pattern: "[0-9]*"
-
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - species:
+        type: string
+        description: Latin name of the species for which a mitochondrial genome should
+          be fetched
+        pattern: "[A-Z]?[a-z]* [a-z]*"
 output:
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
   - fasta:
-      type: file
-      description: Downloaded mitochondrial genome in Fasta format
-      pattern: "*.{fasta,fa}"
+      - meta:
+          type: file
+          description: Downloaded mitochondrial genome in Fasta format
+          pattern: "*.{fasta,fa}"
+      - "*.fasta":
+          type: file
+          description: Downloaded mitochondrial genome in Fasta format
+          pattern: "*.{fasta,fa}"
   - gb:
-      type: file
-      description: Downloaded mitochondrial genome in Genbank format
-      pattern: "*.gb"
-
+      - meta:
+          type: file
+          description: Downloaded mitochondrial genome in Genbank format
+          pattern: "*.gb"
+      - "*.gb":
+          type: file
+          description: Downloaded mitochondrial genome in Genbank format
+          pattern: "*.gb"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
+  - "@verku"
+maintainers:
   - "@verku"

--- a/modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff
+++ b/modules/nf-core/mitohifi/findmitoreference/mitohifi-findmitoreference.diff
@@ -1,30 +1,27 @@
-Changes in module 'nf-core/mitohifi/findmitoreference'
+Changes in component 'nf-core/mitohifi/findmitoreference'
+'modules/nf-core/mitohifi/findmitoreference/meta.yml' is unchanged
+Changes in 'mitohifi/findmitoreference/main.nf':
 --- modules/nf-core/mitohifi/findmitoreference/main.nf
 +++ modules/nf-core/mitohifi/findmitoreference/main.nf
-@@ -1,11 +1,10 @@
+@@ -1,6 +1,7 @@
  process MITOHIFI_FINDMITOREFERENCE {
+     tag "$species"
+     label 'process_single'
 +    secret 'NCBI_API_KEY'
-+
-     tag '$species'
-     label 'process_low'
  
--    // Docker image available at the biocontainers Dockerhub
--    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
--        'docker://biocontainers/mitohifi:3.0.0_cv1':
--        'docker.io/biocontainers/mitohifi:3.0.0_cv1' }"
-+    container 'ghcr.io/marcelauliano/mitohifi:master'
- 
-     input:
-     val species
-@@ -26,7 +25,8 @@
-         --species $species \\
-         --email $email \\
-         --min_length $min_length \\
--        --outfolder .
-+        --outfolder . \\
+     // Docker image available at the project github repository
+     container 'ghcr.io/marcelauliano/mitohifi:3.2.3'
+@@ -23,7 +24,8 @@
+     findMitoReference.py \\
+         --species "$species" \\
+         --outfolder . \\
+-        $args
++        $args \\
 +        --ncbi-api-key \${NCBI_API_KEY}
  
      cat <<-END_VERSIONS > versions.yml
      "${task.process}":
 
+'modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test.snap' is unchanged
+'modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test' is unchanged
 ************************************************************

--- a/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test
+++ b/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test
@@ -1,0 +1,52 @@
+nextflow_process {
+
+    name "Test Process MITOHIFI_FINDMITOREFERENCE"
+    script "../main.nf"
+    process "MITOHIFI_FINDMITOREFERENCE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "mitohifi"
+    tag "mitohifi/findmitoreference"
+
+    test("mitohifi - findmitoreference - homo sapiens") {
+
+        when {
+            process {
+                """
+                input[0] = [[id: "test"], "Homo sapiens"]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("mitohifi - findmitoreference - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [[id: "test"], "Homo sapiens"]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test.snap
+++ b/modules/nf-core/mitohifi/findmitoreference/tests/main.nf.test.snap
@@ -1,0 +1,100 @@
+{
+    "mitohifi - findmitoreference - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "accession.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,ca8d8bb4eccd4fec95ac8cf7f45c3328"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "accession.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gb": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "accession.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ca8d8bb4eccd4fec95ac8cf7f45c3328"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-11T13:59:46.99941331"
+    },
+    "mitohifi - findmitoreference - homo sapiens": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "PV166900.1.fasta:md5,0ff2d09e1f8d0a1a4896d589432350de"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "PV166900.1.gb:md5,943da7249956af9ef17e4fb84d850501"
+                    ]
+                ],
+                "2": [
+                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "PV166900.1.fasta:md5,0ff2d09e1f8d0a1a4896d589432350de"
+                    ]
+                ],
+                "gb": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "PV166900.1.gb:md5,943da7249956af9ef17e4fb84d850501"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,a27cd2130904385aca2a6e09203f3528"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-11T13:39:35.836764006"
+    }
+}

--- a/modules/nf-core/mitohifi/mitohifi/environment.yml
+++ b/modules/nf-core/mitohifi/mitohifi/environment.yml
@@ -1,4 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-  - defaults

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -4,7 +4,7 @@ process MITOHIFI_MITOHIFI {
 
 
     // Docker image available at the project github repository
-    container 'ghcr.io/marcelauliano/mitohifi:master'
+    container 'ghcr.io/marcelauliano/mitohifi:3.2.3'
 
     input:
     tuple val(meta), path(input)
@@ -45,27 +45,31 @@ process MITOHIFI_MITOHIFI {
     if (! ["c", "r"].contains(input_mode)) {
         error "r for reads or c for contigs must be specified"
     }
+    def VERSION = '3.2.3' // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
     """
     mitohifi.py -${input_mode} ${input} \\
         -f ${ref_fa} \\
         -g ${ref_gb} \\
         -o ${mito_code} \\
         -t $task.cpus ${args}
+
+    ## old version command: \$(mitohifi.py -v | sed 's/.* //')
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//' )
+        mitohifi: ${VERSION}
     END_VERSIONS
     """
 
     stub:
+    def VERSION = '3.2.3' // WARN: Incorrect version information is provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch final_mitogenome.fasta
-    touch final_mitogenome.fasta
+    touch final_mitogenome.gb
     touch contigs_stats.tsv
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        mitohifi: \$( mitohifi.py --version 2>&1 | head -n1 | sed 's/^.*MitoHiFi //; s/ .*\$//')
+        mitohifi: ${VERSION}
     END_VERSIONS
     """
 }

--- a/modules/nf-core/mitohifi/mitohifi/main.nf
+++ b/modules/nf-core/mitohifi/mitohifi/main.nf
@@ -10,6 +10,7 @@ process MITOHIFI_MITOHIFI {
     tuple val(meta), path(input)
     path ref_fa
     path ref_gb
+    val input_mode
     val mito_code
 
     output:
@@ -37,16 +38,15 @@ process MITOHIFI_MITOHIFI {
     script:
     // Exit if running this module with -profile conda / -profile mamba
     if (workflow.profile.tokenize(',').intersect(['conda', 'mamba']).size() >= 1) {
-        exit 1, "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
+        error "MitoHiFi module does not support Conda. Please use Docker / Singularity instead."
     }
 
     def args = task.ext.args ?: ''
-    def args2 = task.ext.args2 ?: ''
-    def script_input = args2.equals("-r") ? "-r ${input}" :
-                args2.equals("-c") ? "-c ${input}" :
-                exit("-r for reads or -c for contigs must be specified")
+    if (! ["c", "r"].contains(input_mode)) {
+        error "r for reads or c for contigs must be specified"
+    }
     """
-    mitohifi.py ${script_input} \\
+    mitohifi.py -${input_mode} ${input} \\
         -f ${ref_fa} \\
         -g ${ref_gb} \\
         -o ${mito_code} \\

--- a/modules/nf-core/mitohifi/mitohifi/meta.yml
+++ b/modules/nf-core/mitohifi/mitohifi/meta.yml
@@ -12,92 +12,188 @@ tools:
       tool_dev_url: https://github.com/marcelauliano/MitoHiFi
       doi: "10.1101/2022.12.23.521667"
       licence: ["MIT"]
+      identifier: biotools:mitohifi
 input:
-  - input:
-      type: file
-      description: Path to PacBio HiFi reads or contigs. Type (-r/-c) is specified in ext.args2
-      pattern: "*.{fa,fa.gz,fasta,fasta.gz}"
-  - ref_fa:
-      type: file
-      description: Reference sequence
-      pattern: "*.{fa,fasta}"
-  - ref_gb:
-      type: file
-      description: Reference annotation
-      pattern: "*.{gb}"
-  - code:
-      type: integer
-      description: Mitochndrial code for annotation
-      pattern: "[0-9]*"
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - input:
+        type: file
+        description: Path to PacBio HiFi reads or contigs. Type (-r/-c) is specified
+          in ext.args2
+        pattern: "*.{fa,fa.gz,fasta,fasta.gz}"
+  - - ref_fa:
+        type: file
+        description: Reference sequence
+        pattern: "*.{fa,fasta}"
+  - - ref_gb:
+        type: file
+        description: Reference annotation
+        pattern: "*.{gb}"
+  - - input_mode:
+        type: string
+        description: Specifies type of input - reads or contigs
+        pattern: "{r,c}"
+  - - mito_code:
+        type: string
+        description: Mitochondrial genetic code
 output:
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
   - fasta:
-      type: file
-      description: Mitochondrial sequence
-      pattern: "*.{fasta,fa}"
+      - meta:
+          type: file
+          description: Mitochondrial sequence
+          pattern: "*.{fasta,fa}"
+      - "*fasta":
+          type: file
+          description: Mitochondrial sequence
+          pattern: "*.{fasta,fa}"
+  - stats:
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*contigs_stats.tsv":
+          type: file
+          description: Contigs statistics
+          pattern: "*contigs_stats.tsv"
   - gb:
-      type: file
-      description: Genome annotation in case mitofinder was used
-      pattern: "*.gb"
+      - meta:
+          type: file
+          description: Genome annotation in case mitofinder was used
+          pattern: "*.gb"
+      - "*gb":
+          type: file
+          description: Genome annotation in case mitofinder was used
+          pattern: "*.gb"
   - gff:
-      type: file
-      description: Genome annotation in case mitos was used
-      pattern: "*.gff"
+      - meta:
+          type: file
+          description: Genome annotation in case mitos was used
+          pattern: "*.gff"
+      - "*gff":
+          type: file
+          description: Genome annotation in case mitos was used
+          pattern: "*.gff"
   - all_potential_contigs:
-      type: file
-      description: Contains sequences of all potential contigs
-      pattern: "*all_potential_contigs.fa"
+      - meta:
+          type: file
+          description: Contains sequences of all potential contigs
+          pattern: "*all_potential_contigs.fa"
+      - "*all_potential_contigs.fa":
+          type: file
+          description: Contains sequences of all potential contigs
+          pattern: "*all_potential_contigs.fa"
   - contigs_annotations:
-      type: file
-      description: Graphical representation of annotated genes and tRNAs
-      pattern: "*contigs_annotations.png"
+      - meta:
+          type: file
+          description: Graphical representation of annotated genes and tRNAs
+          pattern: "*contigs_annotations.png"
+      - "*contigs_annotations.png":
+          type: file
+          description: Graphical representation of annotated genes and tRNAs
+          pattern: "*contigs_annotations.png"
   - contigs_circularization:
-      type: directory
-      description: Contains circularization reports
-      pattern: "*contigs_circularization"
+      - meta:
+          type: directory
+          description: Contains circularization reports
+          pattern: "*contigs_circularization"
+      - "*contigs_circularization":
+          type: directory
+          description: Contains circularization reports
+          pattern: "*contigs_circularization"
   - contigs_filtering:
-      type: directory
-      description: Contains files with initial blast matches
-      pattern: "*contigs_filtering"
+      - meta:
+          type: directory
+          description: Contains files with initial blast matches
+          pattern: "*contigs_filtering"
+      - "*contigs_filtering":
+          type: directory
+          description: Contains files with initial blast matches
+          pattern: "*contigs_filtering"
   - coverage_mapping:
-      type: directory
-      description: Contains statistics on coverage mapping
-      pattern: "*coverage_mapping"
+      - meta:
+          type: directory
+          description: Contains statistics on coverage mapping
+          pattern: "*coverage_mapping"
+      - "*coverage_mapping":
+          type: directory
+          description: Contains statistics on coverage mapping
+          pattern: "*coverage_mapping"
   - coverage_plot:
-      type: file
-      description: Read coverage plot for mitochondrial contigs
-      pattern: "*coverage_plot.png"
+      - meta:
+          type: file
+          description: Read coverage plot for mitochondrial contigs
+          pattern: "*coverage_plot.png"
+      - "*coverage_plot.png":
+          type: file
+          description: Read coverage plot for mitochondrial contigs
+          pattern: "*coverage_plot.png"
   - final_mitogenome_annotation:
-      type: file
-      description: Graphical representation of annotated genes for the final mito contig
-      pattern: "*final_mitogenome.annotation.png"
+      - meta:
+          type: file
+          description: Graphical representation of annotated genes for the final mito
+            contig
+          pattern: "*final_mitogenome.annotation.png"
+      - "*final_mitogenome.annotation.png":
+          type: file
+          description: Graphical representation of annotated genes for the final mito
+            contig
+          pattern: "*final_mitogenome.annotation.png"
   - final_mitogenome_choice:
-      type: directory
-      description: Files with potential contigs clusterings and alignments
-      pattern: "*final_mitogenome_choice"
+      - meta:
+          type: directory
+          description: Files with potential contigs clusterings and alignments
+          pattern: "*final_mitogenome_choice"
+      - "*final_mitogenome_choice":
+          type: directory
+          description: Files with potential contigs clusterings and alignments
+          pattern: "*final_mitogenome_choice"
   - final_mitogenome_coverage:
-      type: file
-      description: Graphical representation of reads coverage plot for the final mito contig
-      pattern: "*final_mitogenome.coverage.png"
+      - meta:
+          type: file
+          description: Graphical representation of reads coverage plot for the final mito
+            contig
+          pattern: "*final_mitogenome.coverage.png"
+      - "*final_mitogenome.coverage.png":
+          type: file
+          description: Graphical representation of reads coverage plot for the final mito
+            contig
+          pattern: "*final_mitogenome.coverage.png"
   - potential_contigs:
-      type: directory
-      description: Files with sequences and annotations of the potential contigs
-      pattern: "*potential_contigs"
+      - meta:
+          type: directory
+          description: Files with sequences and annotations of the potential contigs
+          pattern: "*potential_contigs"
+      - "*potential_contigs":
+          type: directory
+          description: Files with sequences and annotations of the potential contigs
+          pattern: "*potential_contigs"
   - reads_mapping_and_assembly:
-      type: directory
-      description: Read mapping files for run from the raw reads
-      pattern: "*reads_mapping_and_assembly"
+      - meta:
+          type: directory
+          description: Read mapping files for run from the raw reads
+          pattern: "*reads_mapping_and_assembly"
+      - "*reads_mapping_and_assembly":
+          type: directory
+          description: Read mapping files for run from the raw reads
+          pattern: "*reads_mapping_and_assembly"
   - shared_genes:
-      type: directory
-      description: Report on genes shared with the reference genome
-      pattern: "*shared_genes.tsv"
+      - meta:
+          type: directory
+          description: Report on genes shared with the reference genome
+          pattern: "*shared_genes.tsv"
+      - "*shared_genes.tsv":
+          type: directory
+          description: Report on genes shared with the reference genome
+          pattern: "*shared_genes.tsv"
   - versions:
-      type: file
-      description: Software versions used in the run
-      pattern: "versions.yml"
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@ksenia-krasheninnikova"
 maintainers:

--- a/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test
+++ b/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test
@@ -1,0 +1,118 @@
+nextflow_process {
+
+    name "Test Process MITOHIFI_MITOHIFI"
+    script "../main.nf"
+    process "MITOHIFI_MITOHIFI"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "mitohifi"
+    tag "mitohifi/mitohifi"
+
+    test("mitohifi - mitohifi - deilephila_porcellus - contigs mode") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    [[id:"ilDeiPorc1"],
+                    file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/ilDeiPorc1.contigs.fa", checkIfExists: true)
+                ])
+                input[1] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true))
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true))
+                input[3] = Channel.of('c')
+                input[4] = Channel.of(5)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.fasta,
+                    process.out.stats,
+                    process.out.gb,
+                    process.out.gff,
+                    process.out.contigs_annotations,
+                    process.out.coverage_plot,
+                    process.out.final_mitogenome_annotation,
+                    process.out.final_mitogenome_coverage,
+                    process.out.shared_genes,
+                    process.out.contigs_annotations,
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("mitohifi - mitohifi - deilephila_porcellus - reads mode") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    [[id:"ilDeiPorc1"],
+                    file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/ilDeiPorc1.HiFi.reads.fa", checkIfExists: true)
+                ])
+                input[1] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true))
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true))
+                input[3] = Channel.of('r')
+                input[4] = Channel.of(5)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.fasta,
+                    process.out.stats,
+                    process.out.gb,
+                    process.out.gff,
+                    process.out.contigs_annotations,
+                    process.out.coverage_plot,
+                    process.out.final_mitogenome_annotation,
+                    process.out.final_mitogenome_coverage,
+                    process.out.shared_genes,
+                    process.out.contigs_annotations,
+                    process.out.versions
+                    ).match()
+                }
+            )
+        }
+
+    }
+
+    test("mitohifi - mitohifi - deilephila_porcellus - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of(
+                    [[id:"ilDeiPorc1"],
+                    file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/ilDeiPorc1.contigs.fa", checkIfExists: true)
+                ])
+                input[1] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.fasta", checkIfExists: true))
+                input[2] = Channel.of(file(params.modules_testdata_base_path + "genomics/eukaryotes/deilephila_porcellus/mito/MW539688.1.gb", checkIfExists: true))
+                input[3] = Channel.of('c')
+                input[4] = Channel.of(5)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test.snap
+++ b/modules/nf-core/mitohifi/mitohifi/tests/main.nf.test.snap
@@ -1,0 +1,312 @@
+{
+    "mitohifi - mitohifi - deilephila_porcellus - contigs mode": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    [
+                        "final_mitogenome.fasta:md5,5654c418bbf991483d9e618dd849af03",
+                        "fixed_header_contigs.fasta:md5,09b3f007191651b1878966c94a37d2d4"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_stats.tsv:md5,b51dade55a40fde0fb1d945373134aa2"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.gb:md5,3b4659a0d7f27fd89510a25c0588909d"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,8b67fe9e504583f6d0bb7ecd2b6e0569"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.annotation.png:md5,fbd90c714aa63329a4cb7bfb316f03ef"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "shared_genes.tsv:md5,bb1cd9cbf4c5073e9edb9da82908031a"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,8b67fe9e504583f6d0bb7ecd2b6e0569"
+                ]
+            ],
+            [
+                "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-11T13:37:07.141537393"
+    },
+    "mitohifi - mitohifi - deilephila_porcellus - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "final_mitogenome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "contigs_stats.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "10": [
+                    
+                ],
+                "11": [
+                    
+                ],
+                "12": [
+                    
+                ],
+                "13": [
+                    
+                ],
+                "14": [
+                    
+                ],
+                "15": [
+                    
+                ],
+                "16": [
+                    "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "final_mitogenome.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    
+                ],
+                "5": [
+                    
+                ],
+                "6": [
+                    
+                ],
+                "7": [
+                    
+                ],
+                "8": [
+                    
+                ],
+                "9": [
+                    
+                ],
+                "all_potential_contigs": [
+                    
+                ],
+                "contigs_annotations": [
+                    
+                ],
+                "contigs_circularization": [
+                    
+                ],
+                "contigs_filtering": [
+                    
+                ],
+                "coverage_mapping": [
+                    
+                ],
+                "coverage_plot": [
+                    
+                ],
+                "fasta": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "final_mitogenome.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "final_mitogenome_annotation": [
+                    
+                ],
+                "final_mitogenome_choice": [
+                    
+                ],
+                "final_mitogenome_coverage": [
+                    
+                ],
+                "gb": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "final_mitogenome.gb:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "gff": [
+                    
+                ],
+                "potential_contigs": [
+                    
+                ],
+                "reads_mapping_and_assembly": [
+                    
+                ],
+                "shared_genes": [
+                    
+                ],
+                "stats": [
+                    [
+                        {
+                            "id": "ilDeiPorc1"
+                        },
+                        "contigs_stats.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-11T14:53:24.840950981"
+    },
+    "mitohifi - mitohifi - deilephila_porcellus - reads mode": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.fasta:md5,f49bee6e046ba58206be0bbb9dc689fd"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_stats.tsv:md5,4227e7245f396feedc4b0e042fc8ab7c"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.gb:md5,10077fa6938d3da1aa875ff6c5585246"
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,0efdb60ca64983f36dd20e9c26a948d4"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "coverage_plot.png:md5,5b21b49d07190f9bee30b19e17c269a0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.annotation.png:md5,93678b20020d52121ebb5e3527317820"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "final_mitogenome.coverage.png:md5,decea4407ddbae9258f6ca2d4f63cb09"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "shared_genes.tsv:md5,5f5c7498ab370f4a2c9b8e5f8b43befa"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "contigs_annotations.png:md5,0efdb60ca64983f36dd20e9c26a948d4"
+                ]
+            ],
+            [
+                "versions.yml:md5,b162f6c6ed3625038a867605484cd250"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "24.10.5"
+        },
+        "timestamp": "2025-03-11T13:50:10.786750796"
+    }
+}

--- a/modules/nf-core/oatk/environment.yml
+++ b/modules/nf-core/oatk/environment.yml
@@ -1,9 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
-name: "oatk"
 channels:
   - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - "bioconda::oatk=1.0"
+  - bioconda::oatk=1.0

--- a/modules/nf-core/oatk/meta.yml
+++ b/modules/nf-core/oatk/meta.yml
@@ -1,4 +1,3 @@
----
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "oatk"
 description: An nf-core module for the OATK
@@ -17,147 +16,195 @@ tools:
       tool_dev_url: "https://github.com/c-zhou/oatk"
       doi: "10.5281/zenodo.10400173"
       licence: ["MIT"]
+      identifier: ""
 
 input:
   # Only when we have meta
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'Cladonia_norvegica' ]
-
-  - reads:
-      type: file
-      description: HiFi reads in FASTA format
-      pattern: "*.{fasta,fasta.gz,fa,fa.gz}"
-
-  - mito_hmm:
-      type: file
-      description: mitochondria gene annotation HMM profile database
-      pattern: "*.{fa,fam}"
-
-  - mito_hmm_h3f:
-      type: file
-      description: mitochondria gene annotation HMM profile binary auxfile
-      pattern: "*.{h3f}"
-
-  - mito_hmm_h3i:
-      type: file
-      description: mitochondria gene annotation HMM profile binary auxfile
-      pattern: "*.{h3i}"
-
-  - mito_hmm_h3m:
-      type: file
-      description: mitochondria gene annotation HMM profile binary auxfile
-      pattern: "*.{h3m}"
-
-  - mito_hmm_h3p:
-      type: file
-      description: mitochondria gene annotation HMM profile binary auxfile
-      pattern: "*.{h3p}"
-
-  - pltd_hmm:
-      type: file
-      description: plastid gene annotation HMM profile database
-      pattern: "*.{fa,fam}"
-
-  - pltd_hmm_h3f:
-      type: file
-      description: plastid gene annotation HMM profile binary auxfile
-      pattern: "*.{h3f}"
-
-  - pltd_hmm_h3i:
-      type: file
-      description: plastid gene annotation HMM profile binary auxfile
-      pattern: "*.{h3i}"
-
-  - pltd_hmm_h3m:
-      type: file
-      description: plastid gene annotation HMM profile binary auxfile
-      pattern: "*.{h3m}"
-
-  - pltd_hmm_h3p:
-      type: file
-      description: plastid gene annotation HMM profile binary auxfile
-      pattern: "*.{h3p}"
-
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'Cladonia_norvegica' ]
+    - reads:
+        type: file
+        description: HiFi reads in FASTA format
+        pattern: "*.{fasta,fasta.gz,fa,fa.gz}"
+  - - mito_hmm:
+        type: file
+        description: mitochondria gene annotation HMM profile database
+        pattern: "*.{fa,fam}"
+    - mito_hmm_h3f:
+        type: file
+        description: mitochondria gene annotation HMM profile binary auxfile
+        pattern: "*.{h3f}"
+    - mito_hmm_h3i:
+        type: file
+        description: mitochondria gene annotation HMM profile binary auxfile
+        pattern: "*.{h3i}"
+    - mito_hmm_h3m:
+        type: file
+        description: mitochondria gene annotation HMM profile binary auxfile
+        pattern: "*.{h3m}"
+    - mito_hmm_h3p:
+        type: file
+        description: mitochondria gene annotation HMM profile binary auxfile
+        pattern: "*.{h3p}"
+  - - pltd_hmm:
+        type: file
+        description: plastid gene annotation HMM profile database
+        pattern: "*.{fa,fam}"
+    - pltd_hmm_h3f:
+        type: file
+        description: plastid gene annotation HMM profile binary auxfile
+        pattern: "*.{h3f}"
+    - pltd_hmm_h3i:
+        type: file
+        description: plastid gene annotation HMM profile binary auxfile
+        pattern: "*.{h3i}"
+    - pltd_hmm_h3m:
+        type: file
+        description: plastid gene annotation HMM profile binary auxfile
+        pattern: "*.{h3m}"
+    - pltd_hmm_h3p:
+        type: file
+        description: plastid gene annotation HMM profile binary auxfile
+        pattern: "*.{h3p}"
 output:
   #Only when we have meta
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
-
-  - versions:
-      type: file
-      description: File containing software versions
-      pattern: "versions.yml"
-
   - mito_fasta:
-      type: file
-      description: the structure-solved MT contigs
-      pattern: "*mito.ctg.fasta"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*mito.ctg.fasta":
+          type: file
+          description: the structure-solved MT contigs
+          pattern: "*mito.ctg.fasta"
   - pltd_fasta:
-      type: file
-      description: the structure-solved PT contigs
-      pattern: "*pltd.ctg.fasta"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*pltd.ctg.fasta":
+          type: file
+          description: the structure-solved PT contigs
+          pattern: "*pltd.ctg.fasta"
   - mito_bed:
-      type: file
-      description: the gene annotation for the MT sequences
-      pattern: "*mito.ctg.bed"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*mito.ctg.bed":
+          type: file
+          description: the gene annotation for the MT sequences
+          pattern: "*mito.ctg.bed"
   - pltd_bed:
-      type: file
-      description: the gene annotation for the PT sequences
-      pattern: "*pltd.ctg.bed"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*pltd.ctg.bed":
+          type: file
+          description: the gene annotation for the PT sequences
+          pattern: "*pltd.ctg.bed"
   - mito_gfa:
-      type: file
-      description: the subgraph for the MT genome
-      pattern: "*mito.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*mito.gfa":
+          type: file
+          description: the subgraph for the MT genome
+          pattern: "*mito.gfa"
   - pltd_gfa:
-      type: file
-      description: the subgraph for the PT genome
-      pattern: "*pltd.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*pltd.gfa":
+          type: file
+          description: the subgraph for the PT genome
+          pattern: "*pltd.gfa"
   - annot_mito_txt:
-      type: file
-      description: the MT gene annotation file over all assembled sequences
-      pattern: "*annot_mito.txt"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*annot_mito.txt":
+          type: file
+          description: the MT gene annotation file over all assembled sequences
+          pattern: "*annot_mito.txt"
   - annot_pltd_txt:
-      type: file
-      description: the PT gene annotation file over all assembled sequences
-      pattern: "*annot_pltd.txt"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*annot_pltd.txt":
+          type: file
+          description: the PT gene annotation file over all assembled sequences
+          pattern: "*annot_pltd.txt"
   - clean_gfa:
-      type: file
-      description: the GFA file for the clean genome assembly
-      pattern: "*utg.clean.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*utg.clean.gfa":
+          type: file
+          description: the GFA file for the clean genome assembly
+          pattern: "*utg.clean.gfa"
   - final_gfa:
-      type: file
-      description: the GFA file for the final genome assembly
-      pattern: "*utg.final.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*utg.final.gfa":
+          type: file
+          description: the GFA file for the final genome assembly
+          pattern: "*utg.final.gfa"
   - initial_gfa:
-      type: file
-      description: the GFA file for the initial genome assembly
-      pattern: "*utg.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*utg.gfa":
+          type: file
+          description: the GFA file for the initial genome assembly
+          pattern: "*utg.gfa"
   - multiplex_gfa:
-      type: file
-      description: the mutliplexed GFA file
-      pattern: "*utg.multiplex.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*utg.multiplex.gfa":
+          type: file
+          description: the mutliplexed GFA file
+          pattern: "*utg.multiplex.gfa"
   - unzip_gfa:
-      type: file
-      description: the unzipped GFA file
-      pattern: "*utg.unzip.gfa"
-
+      - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*utg.unzip.gfa":
+          type: file
+          description: the unzipped GFA file
+          pattern: "*utg.unzip.gfa"
+  - versions:
+      - versions.yml:
+          type: file
+          description: File containing software versions
+          pattern: "versions.yml"
 authors:
   - "@ksenia-krasheninnikova"

--- a/modules/nf-core/oatk/tests/main.nf.test
+++ b/modules/nf-core/oatk/tests/main.nf.test
@@ -19,8 +19,8 @@ nextflow_process {
             }
             process {
                     """
-                    input[0] = Channel.of([[id:"ilDeiPorc1"],file(params.test_data['deilephila_porcellus']['mito']['hifi_reads'], checkIfExists: true)])
-                    
+                    input[0] = Channel.of([[id:"ilDeiPorc1"],file(params.modules_testdata_base_path + 'genomics/eukaryotes/deilephila_porcellus/mito/ilDeiPorc1.HiFi.reads.fa', checkIfExists: true)])
+
                     hmm = file("https://raw.githubusercontent.com/c-zhou/OatkDB/main/v20230921/insecta_mito.fam", checkIfExists: true)
                     hmm_h3f = file("https://github.com/c-zhou/OatkDB/raw/main/v20230921/insecta_mito.fam.h3f", checkIfExists: true)
                     hmm_h3i = file("https://github.com/c-zhou/OatkDB/raw/main/v20230921/insecta_mito.fam.h3i", checkIfExists: true)
@@ -29,24 +29,27 @@ nextflow_process {
                     input[1] = Channel.of([hmm, hmm_h3f, hmm_h3i, hmm_h3m, hmm_h3p])
                     input[2] = [[],[],[],[],[]]
                     """
-            } 
+            }
         }
 
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.mito_fasta).match("mito_fasta") },
                 { assert process.out.final_gfa.get(0).get(1) ==~ '.*utg.final.gfa' } ,
-                { assert snapshot(process.out.mito_bed).match("mito_bed") }, 
-                { assert snapshot(process.out.mito_gfa).match("mito_gfa") }, 
                 { assert process.out.initial_gfa.get(0).get(1) ==~ '.*utg.gfa' } ,
                 { assert process.out.annot_mito_txt[0][1] ==~ ".*annot_mito.txt" },
-                { assert snapshot(process.out.versions).match("versions") } 
+                { assert snapshot(
+                    process.out.mito_bed,
+                    process.out.mito_fasta,
+                    process.out.mito_gfa,
+                    process.out.versions
+                    ).match()
+                }
             )
         }
 
     }
-    
+
     test("test_oatk_pltd") {
         tag "test_oatk_pltd"
 
@@ -57,8 +60,8 @@ nextflow_process {
             }
             process {
                     """
-                    input[0] = Channel.of([[id:"ddAraThal4"],file(params.test_data['arabidopsis_thaliana']['plastid']['hifi_reads'], checkIfExists: true)])
-                    
+                    input[0] = Channel.of([[id:"ddAraThal4"],file(params.modules_testdata_base_path + 'genomics/eukaryotes/arabidopsis_thaliana/plastid/ddAraThal4.HiFi.reads.fasta', checkIfExists: true)])
+
                     input[1] = [[],[],[],[],[]]
                     hmm = file("https://github.com/c-zhou/OatkDB/raw/main/v20230921/embryophyta_pltd.fam", checkIfExists: true)
                     hmm_h3f = file("https://github.com/c-zhou/OatkDB/raw/main/v20230921/embryophyta_pltd.fam.h3f", checkIfExists: true)
@@ -67,19 +70,22 @@ nextflow_process {
                     hmm_h3p = file("https://github.com/c-zhou/OatkDB/raw/main/v20230921/embryophyta_pltd.fam.h3p", checkIfExists: true)
                     input[2] = Channel.of([hmm, hmm_h3f, hmm_h3i, hmm_h3m, hmm_h3p])
                     """
-            } 
+            }
         }
 
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.pltd_fasta).match("pltd_fasta") },
                 { assert process.out.final_gfa.get(0).get(1) ==~ '.*utg.final.gfa' } ,
-                { assert snapshot(process.out.pltd_bed).match("pltd_bed") }, 
-                { assert snapshot(process.out.pltd_gfa).match("pltd_gfa") }, 
                 { assert process.out.initial_gfa.get(0).get(1) ==~ '.*utg.gfa' } ,
                 { assert process.out.annot_pltd_txt[0][1] ==~ ".*annot_pltd.txt" },
-                { assert snapshot(process.out.versions).match("versions") } 
+                { assert snapshot(
+                    process.out.pltd_bed,
+                    process.out.pltd_fasta,
+                    process.out.pltd_gfa,
+                    process.out.versions
+                    ).match()
+                }
             )
         }
 

--- a/modules/nf-core/oatk/tests/main.nf.test.snap
+++ b/modules/nf-core/oatk/tests/main.nf.test.snap
@@ -1,52 +1,5 @@
 {
-    "mito_bed": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "ilDeiPorc1"
-                    },
-                    "ilDeiPorc1.mito.ctg.bed:md5,177c87cb89996306611f6e74dba2ff60"
-                ]
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:03.325434126"
-    },
-    "mito_gfa": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "ilDeiPorc1"
-                    },
-                    "ilDeiPorc1.mito.gfa:md5,88a058195aad319f57a330acea5357c5"
-                ]
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:03.334475394"
-    },
-    "versions": {
-        "content": [
-            [
-                "versions.yml:md5,bc3c4d7a42644e2c0d71422677a7d915"
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:03.361579579"
-    },
-    "mito_fasta": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "ilDeiPorc1"
-                    },
-                    "ilDeiPorc1.mito.ctg.fasta:md5,822b20d9e8f13591cb3a7474fda97402"
-                ]
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:03.305999918"
-    },
-    "pltd_bed": {
+    "test_oatk_pltd": {
         "content": [
             [
                 [
@@ -55,25 +8,7 @@
                     },
                     "ddAraThal4.pltd.ctg.bed:md5,f5925e6ec605b83547b9c72fae6f7087"
                 ]
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:15.844572574"
-    },
-    "pltd_gfa": {
-        "content": [
-            [
-                [
-                    {
-                        "id": "ddAraThal4"
-                    },
-                    "ddAraThal4.pltd.gfa:md5,9749ffa1ebbf6b71fd7c9e8b410d64d4"
-                ]
-            ]
-        ],
-        "timestamp": "2024-01-22T11:28:15.860281161"
-    },
-    "pltd_fasta": {
-        "content": [
+            ],
             [
                 [
                     {
@@ -81,8 +16,59 @@
                     },
                     "ddAraThal4.pltd.ctg.fasta:md5,88cf092fd935801029a26bf88f6063bf"
                 ]
+            ],
+            [
+                [
+                    {
+                        "id": "ddAraThal4"
+                    },
+                    "ddAraThal4.pltd.gfa:md5,9749ffa1ebbf6b71fd7c9e8b410d64d4"
+                ]
+            ],
+            [
+                "versions.yml:md5,bc3c4d7a42644e2c0d71422677a7d915"
             ]
         ],
-        "timestamp": "2024-01-22T11:28:15.81801003"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-30T16:28:09.782502"
+    },
+    "test_oatk_mito": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "ilDeiPorc1.mito.ctg.bed:md5,177c87cb89996306611f6e74dba2ff60"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "ilDeiPorc1.mito.ctg.fasta:md5,822b20d9e8f13591cb3a7474fda97402"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "ilDeiPorc1"
+                    },
+                    "ilDeiPorc1.mito.gfa:md5,88a058195aad319f57a330acea5357c5"
+                ]
+            ],
+            [
+                "versions.yml:md5,bc3c4d7a42644e2c0d71422677a7d915"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.3"
+        },
+        "timestamp": "2024-07-30T16:27:44.199733"
     }
 }

--- a/subworkflows/local/organelles.nf
+++ b/subworkflows/local/organelles.nf
@@ -18,15 +18,12 @@ workflow ORGANELLES {
     //
     // LOGIC: SEPARATE INPUT INTO CHANNELS
     //
-    mito_info.map{ species, min_length, code, email, fam -> species}.set{species}
-    mito_info.map{ species, min_length, code, email, fam -> min_length}.set{min_length}
-    mito_info.map{ species, min_length, code, email, fam -> code}.set{code}
-    mito_info.map{ species, min_length, code, email, fam -> email}.set{email}
+    mito_info.map{ species, min_length, code, email, fam -> [[min_length: min_length], species]}.set{species}
 
     //
     // MODULE: DOWNLOAD REFERENCE ORGANELLE ASSEMBLY
     //
-    MITOHIFI_FINDMITOREFERENCE(species, email, min_length)
+    MITOHIFI_FINDMITOREFERENCE(species)
     ch_versions = ch_versions.mix(MITOHIFI_FINDMITOREFERENCE.out.versions.first())
         
     //

--- a/subworkflows/local/organelles.nf
+++ b/subworkflows/local/organelles.nf
@@ -35,6 +35,7 @@ workflow ORGANELLES {
     MITOHIFI_MITOHIFI_READS( reads_input, 
                    MITOHIFI_FINDMITOREFERENCE.out.fasta,
                    MITOHIFI_FINDMITOREFERENCE.out.gb,
+                   "r",
                    code)    
     ch_versions = ch_versions.mix(MITOHIFI_FINDMITOREFERENCE.out.versions.first())
 
@@ -44,6 +45,7 @@ workflow ORGANELLES {
     MITOHIFI_MITOHIFI_CONTIGS( contigs_input, 
                    MITOHIFI_FINDMITOREFERENCE.out.fasta,
                    MITOHIFI_FINDMITOREFERENCE.out.gb,
+                   "c",
                    code)    
     ch_versions = ch_versions.mix(MITOHIFI_FINDMITOREFERENCE.out.versions.first())
 

--- a/subworkflows/local/organelles.nf
+++ b/subworkflows/local/organelles.nf
@@ -19,6 +19,7 @@ workflow ORGANELLES {
     // LOGIC: SEPARATE INPUT INTO CHANNELS
     //
     mito_info.map{ species, min_length, code, email, fam -> [[min_length: min_length], species]}.set{species}
+    mito_info.map{ species, min_length, code, email, fam -> code}.set{code}
 
     //
     // MODULE: DOWNLOAD REFERENCE ORGANELLE ASSEMBLY

--- a/subworkflows/local/prepare_input.nf
+++ b/subworkflows/local/prepare_input.nf
@@ -26,7 +26,7 @@ workflow PREPARE_INPUT {
     ymlfile.multiMap{ data -> 
         dataset : (data.dataset ? data.dataset : []) 
         busco : (data.busco ? data.busco : [])
-        mito: ( data.mito ? ['\"'+data.mito.species+'\"', data.mito.min_length, data.mito.code, data.mito.email ? data.mito.email : "\"\"", data.mito.fam ? file(data.mito.fam, checkIfExists: true) : [] ] : [])
+        mito: ( data.mito ? [data.mito.species, data.mito.min_length, data.mito.code, data.mito.email ? data.mito.email : "\"\"", data.mito.fam ? file(data.mito.fam, checkIfExists: true) : [] ] : [])
         plastid : ( data.plastid ? ( data.plastid.fam ? file(data.plastid.fam, checkIfExists: true) : [] ) : [])
         hic_motif : (data.hic_motif ? data.hic_motif : [])
         hic_aligner : (data.hic_aligner ? data.hic_aligner :[])


### PR DESCRIPTION
Fixes:
- mitohifi - update to newest version of module
- hifiasm - patch environment file to remove channel
- oatk - update to newest version of module
- minimap2/index - patch environment file to remove channel
- lib/Utils.groovy channel check

I patched the modules for hifiasm and minimap2/align as the newer module versions come with software version updates.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
