### PR TITLE
fix(pipeline): switch from pipes to dot for operators for language server compatibility

### DIFF
--- a/subworkflows/local/organelle_assembly/main.nf
+++ b/subworkflows/local/organelle_assembly/main.nf
@@ -36,9 +36,9 @@ workflow ORGANELLE_ASSEMBLY {
         ch_versions = ch_versions.mix(CONCATENATE_INPUT_READS.out.versions)
 
         ch_mitohifi_reads_input = CONCATENATE_INPUT_READS.out.file_out
-            | combine(MITOHIFI_FINDMITOREFERENCE.out.fasta)
-            | combine(MITOHIFI_FINDMITOREFERENCE.out.gb)
-            | multiMap { meta, reads, _meta_fasta, fasta, _meta_gb, gb ->
+            .combine(MITOHIFI_FINDMITOREFERENCE.out.fasta)
+            .combine(MITOHIFI_FINDMITOREFERENCE.out.gb)
+            .multiMap { meta, reads, _meta_fasta, fasta, _meta_gb, gb ->
                 reads: [ meta, reads ]
                 fasta: [ meta, fasta ]
                 gb:    [ meta, gb ]
@@ -59,7 +59,7 @@ workflow ORGANELLE_ASSEMBLY {
         // Module: Concatenate assembly pairs for Mitohifi
         //
         ch_concat_input = ch_assemblies
-            | map { meta, asm1, asm2 -> [ meta, [asm1, asm2] ] }
+            .map { meta, asm1, asm2 -> [ meta, [asm1, asm2] ] }
 
         CONCATENATE_ASSEMBLIES(ch_concat_input)
         ch_versions = ch_versions.mix(CONCATENATE_ASSEMBLIES.out.versions)
@@ -68,9 +68,9 @@ workflow ORGANELLE_ASSEMBLY {
         // Module: Identify organelle from assembled contigs with Mitohifi
         //
         ch_mitohifi_contigs_input = CONCATENATE_ASSEMBLIES.out.file_out
-            | combine(MITOHIFI_FINDMITOREFERENCE.out.fasta)
-            | combine(MITOHIFI_FINDMITOREFERENCE.out.gb)
-            | multiMap { meta, asm, _meta_fasta, fasta, _meta_gb, gb ->
+            .combine(MITOHIFI_FINDMITOREFERENCE.out.fasta)
+            .combine(MITOHIFI_FINDMITOREFERENCE.out.gb)
+            .multiMap { meta, asm, _meta_fasta, fasta, _meta_gb, gb ->
                 asm:   [ meta, asm ]
                 fasta: [ meta, fasta ]
                 gb:    [ meta, gb ]
@@ -91,7 +91,7 @@ workflow ORGANELLE_ASSEMBLY {
         //        Do it this way as we will move to a channel publishing structure in future
         //
         ch_mitohifi_reads_output = channel.empty()
-            | mix(
+            .mix(
                 MITOHIFI_MITOHIFI_READS.out.fasta,
                 MITOHIFI_MITOHIFI_READS.out.stats,
                 MITOHIFI_MITOHIFI_READS.out.gb,
@@ -111,7 +111,7 @@ workflow ORGANELLE_ASSEMBLY {
             )
 
         ch_mitohifi_contigs_output = channel.empty()
-            | mix(
+            .mix(
                 MITOHIFI_MITOHIFI_READS.out.fasta,
                 MITOHIFI_MITOHIFI_READS.out.stats,
                 MITOHIFI_MITOHIFI_READS.out.gb,
@@ -142,7 +142,7 @@ workflow ORGANELLE_ASSEMBLY {
     ch_versions = ch_versions.mix(OATK.out.versions)
 
     ch_oatk_output = channel.empty()
-        | mix(
+        .mix(
             OATK.out.mito_fasta,
             OATK.out.pltd_fasta,
             OATK.out.mito_bed,

--- a/subworkflows/local/utils_nfcore_genomeassembly_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_genomeassembly_pipeline/main.nf
@@ -100,7 +100,7 @@ workflow PIPELINE_INITIALISATION {
     // Logic: Check that purging and polishing parameter strings only contains valid options
     //
     channel.of([params.purging_assemblytypes, params.polishing_assemblytypes])
-        | map { purging, polishing ->
+        .map { purging, polishing ->
             def valid_types     = ["primary", "hic_phased", "trio_binned"]
             def check_purging   = purging.tokenize(",").collect   { type -> type in valid_types }
             def check_polishing = polishing.tokenize(",").collect { type -> type in valid_types }
@@ -122,18 +122,18 @@ workflow PIPELINE_INITIALISATION {
     // LOGIC: Create channels for reads for raw assembly input
     //        [meta, reads, fk_hist, fk_ktab]
     //
-    ch_long_reads = READ_YAML.out.long_reads     | filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() } | collect
-    ch_hic_reads  = READ_YAML.out.hic_reads      | filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() } | collect
-    ch_i10x_reads = READ_YAML.out.i10x_reads     | filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() } | collect
-    ch_mat_reads  = READ_YAML.out.maternal_reads | filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() } | collect
-    ch_pat_reads  = READ_YAML.out.paternal_reads | filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() } | collect
+    ch_long_reads = READ_YAML.out.long_reads.filter     { _meta, reads, _hist, _ktab -> !reads.isEmpty() }.collect()
+    ch_hic_reads  = READ_YAML.out.hic_reads.filter      { _meta, reads, _hist, _ktab -> !reads.isEmpty() }.collect()
+    ch_i10x_reads = READ_YAML.out.i10x_reads.filter     { _meta, reads, _hist, _ktab -> !reads.isEmpty() }.collect()
+    ch_mat_reads  = READ_YAML.out.maternal_reads.filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() }.collect()
+    ch_pat_reads  = READ_YAML.out.paternal_reads.filter { _meta, reads, _hist, _ktab -> !reads.isEmpty() }.collect()
 
     //
     // LOGIC: Create channels for databases
     //
     ch_busco_lineage = READ_YAML.out.busco_lineage
-    ch_oatk_mito     = READ_YAML.out.oatk_mito_hmm    | filter { list -> !list.isEmpty() } | collect
-    ch_oatk_plastid  = READ_YAML.out.oatk_plastid_hmm | collect
+    ch_oatk_mito     = READ_YAML.out.oatk_mito_hmm.filter { list -> !list.isEmpty() }.collect()
+    ch_oatk_plastid  = READ_YAML.out.oatk_plastid_hmm.collect()
 
     emit:
     long_reads    = ch_long_reads


### PR DESCRIPTION
Apparently the auto-conversion tool that will help migrate to the new Nextflow typed syntax does not support the pipe operator. So I'm just going to move everything across the board in anticipation!

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
