### PR TITLE
feat issue #111: Support multiple haplotypes in assembly pipeline 

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -57,7 +57,7 @@ process {
         ext.prefix = { "asm_${meta._hap}" }
         tag        = { "${meta.assembly_type}_${meta._hap}" }
         ext.args   = {
-            meta._hap == "hap1" ? "-rp '^h1tg|^ptg'" : "-rp '^h2tg|^atg|^hap_'"
+            meta._hap == "hap1" ? "-rp '^h1tg|^ptg'" : "-v -rp '^h1tg|^ptg'"
         }
         publishDir = [
             path: { "${params.outdir}/${mf.assemblyDir(meta, workflow.start)}/polishing" },

--- a/subworkflows/local/raw_assembly/main.nf
+++ b/subworkflows/local/raw_assembly/main.nf
@@ -1,6 +1,7 @@
 include { GAWK as GAWK_GFA_TO_FASTA } from '../../../modules/nf-core/gawk/main'
 include { HIFIASM                   } from '../../../modules/sanger-tol/hifiasm/main'
-include { HIFIASM as HIFIASM_BIN    } from '../../../modules/sanger-tol/hifiasm/main'
+include { HIFIASM as HIFIASM_BIN          } from '../../../modules/sanger-tol/hifiasm/main'
+include { CAT_CAT as CONCATENATE_ALTERNATES } from '../../../modules/nf-core/cat/cat'
 
 workflow RAW_ASSEMBLY {
     take:
@@ -92,29 +93,50 @@ workflow RAW_ASSEMBLY {
     //
     ch_assemblies_fasta = HIFIASM.out.assembly_fasta
         .transpose()
-        .filter { meta, asm ->
-            asm.getName() =~ /^[^.]+\.p_ctg\.fa$/ ||
-            asm.getName() =~ /a_ctg\.fa$/ ||
-            asm.getName() =~ /hap1\.p_ctg\.fa$/ ||
-            asm.getName() =~ /hap2\.p_ctg\.fa$/
-        }
-        .groupTuple(by: 0, size: 2, remainder: true)
-        .flatMap { meta, asms ->
-            if(asms.size() == 1) { return [] }
-            def pri = /hap1.p_ctg.fa$/
-            def alt = /hap2.p_ctg.fa$/
-            if(meta.assembly_type == "primary") {
-                if(asms.findAll { asm -> asm.name =~ /hap/ }.size() == 0) {
-                    pri = /^[^.]+\.p_ctg\.fa$/
-                    alt = /a_ctg.fa$/
-                }
+        .groupTuple(by: 0)
+        .map { meta, asms ->
+            // Identify Primary (hap1.p_ctg.fa or p_ctg.fa)
+            def pri_pattern_hap = /hap1.p_ctg.fa$/
+            def pri_pattern_gen = /^[^.]+\.p_ctg\.fa$/
+
+            // Filter to only keep contig files (*ctg.fa)
+            def ctg_asms = asms.findAll { it.name =~ /ctg.fa/ }
+
+            def pri = ctg_asms.find { it.name =~ pri_pattern_hap }
+            if (!pri) {
+                 // Fallback: check generally for p_ctg.fa if no "hap" naming is used in ANY file
+                 def has_hap = ctg_asms.any { it.name =~ /hap/ }
+                 if (!has_hap) {
+                      pri = ctg_asms.find { it.name =~ pri_pattern_gen }
+                 }
             }
 
-            return [[meta, asms.find { asm -> asm.name =~ pri }, asms.find { asm -> asm.name =~ alt}]]
+            // Alternates are everything else
+            def alts = ctg_asms - pri
+
+            [ meta, pri, alts ]
+        }
+        .branch { meta, pri, alts ->
+             concat: alts.size() > 1
+             ready: true
+        }
+
+    CONCATENATE_ALTERNATES(
+        ch_assemblies_fasta.concat.map { meta, pri, alts -> [ meta, alts ] }
+    )
+    ch_versions = ch_versions.mix(CONCATENATE_ALTERNATES.out.versions)
+
+    ch_assemblies_ready = ch_assemblies_fasta.concat
+        .join(CONCATENATE_ALTERNATES.out.file_out)
+        .map { meta, pri, alts_orig, merged_alt -> [ meta, pri, [merged_alt] ] }
+        .mix(ch_assemblies_fasta.ready)
+        .map { meta, pri, alts ->
+            def alt = alts ? alts[0] : []
+            [ meta, pri, alt ]
         }
 
     emit:
-    hifiasm_fasta = ch_assemblies_fasta
+    hifiasm_fasta = ch_assemblies_ready
     hifiasm_gfa   = HIFIASM.out.assembly_graphs
     hifiasm_bed   = HIFIASM.out.bed
     hifiasm_log   = HIFIASM.out.log


### PR DESCRIPTION
# Support Multiple Haplotypes in Assembly Pipeline

This PR implements support for polyploid assemblies (more than two haplotypes) in the Hifiasm workflow by introducing a "Primary + Merged Alternate" strategy. The pipeline now handles N haplotypes by identifying one as primary and concatenating all others into a single alternate assembly.

## Problem Statement

Currently, the assembly pipeline assumes strict diploidy (hap1/hap2 or pri/alt) from Hifiasm. When polyploid organisms are assembled, the pipeline cannot properly handle the additional haplotype outputs, breaking downstream processing.

## Solution Strategy

**Primary + Merged Alternate Approach:**
- Identify one haplotype as "primary" (hap1)
- Concatenate all remaining haplotypes into a single "alternate" (hap2) assembly
- Preserve existing "primary vs alternate" logic in downstream steps
- Support any number of input haplotypes

## Key Changes

### 1. Splitting Logic Update (conf/modules.config)
- **Change**: From explicit matching (`h2tg`, `atg`, `hap_`) to inverse logic
- **New Logic**: Define "alternate" as "everything that is NOT primary"
- **Primary patterns**: `^h1tg|^ptg`
- **Benefits**: More robust for variable haplotype counts

### 2. Subworkflow Modifications (subworkflows/local/raw_assembly/main.nf)
- **Import**: `CAT_CAT` module for concatenation
- **Logic Updates**:
  - Identify primary file (matching `hap1.p_ctg.fa` or `p_ctg.fa`)
  - Identify alternate files (all other `hap*.p_ctg.fa` or `a_ctg.fa`)
  - Add branching logic:
    - If single alternate file: pass through
    - If multiple alternate files: merge using `CAT_CAT` into single `hap2` file
  - Emit `hap1` and `hap2` (merged alternates)
- **Update**: versions mix

### 3. Configuration Updates (conf/modules.config)
- **Update**: `SEQKIT_GREP_SPLIT_HAPS` configuration
- **Change**: Use inverse matching (`-v`) against primary patterns (`^h1tg|^ptg`)
- **Result**: Captures all non-primary sequences effectively

## Critical Assumption

The splitting logic change assumes that `hap1` (primary) patterns (`h1tg`, `ptg`) are well-defined and exhaustive. This needs validation from the team to ensure it correctly identifies all primary assembly sequences.

## Testing

- [ ] Add tests for polyploid assembly scenarios
- [ ] Verify concatenation logic with multiple haplotypes
- [ ] Ensure downstream steps handle merged alternate correctly

## Future Considerations

- Support user-defined primary haplotype selection
- Add explicit polyploid testing datasets
- Consider alternative strategies for very large numbers of haplotypes

---

**Closes:** #111