### PR TITLE
fix: fix ultralong reads not being used in hifiasm

### DIFF
--- a/assets/schema_assembly.json
+++ b/assets/schema_assembly.json
@@ -43,14 +43,14 @@
                 "type": "string",
                 "description": "A dataset name from the input dataset sheet supplying ultralong reads for assembly.",
                 "pattern": "^\\S+$",
-                "meta": "ultralong_read_dataset"
+                "meta": "ultralong_dataset"
             },
             "ultralong_platform": {
                 "type": "string",
                 "enum": ["oxford_nanopore"],
                 "description": "Use reads from this sequencing platform as the ultralong reads.",
                 "pattern": "^\\S+$",
-                "meta": "ultralong_read_platform"
+                "meta": "ultralong_platform"
             },
             "hic_dataset": {
                 "type": "string",

--- a/modules.json
+++ b/modules.json
@@ -302,7 +302,7 @@
                     },
                     "hifiasm": {
                         "branch": "main",
-                        "git_sha": "d44a0926bfc87999fbbb530b9c0d00a4391586f4",
+                        "git_sha": "51af796b9652098c6227468ff9efff10885e3f35",
                         "installed_by": ["modules"]
                     },
                     "longranger/align": {

--- a/modules/sanger-tol/hifiasm/main.nf
+++ b/modules/sanger-tol/hifiasm/main.nf
@@ -61,7 +61,7 @@ process HIFIASM {
     }
 
     // Set up ultralong reads input
-    def ultralong = ul_reads ? "--ul ${ul_reads_sorted}" : ""
+    def ultralong = ul_reads ? "--ul <(cat ${ul_reads_sorted})" : ""
 
     // Configure log input so that logs are always written to a new file
     def copy_previous_log = previous_log ? "cat log/* > ${prefix}.log" : ""


### PR DESCRIPTION
The names of the variables being made in the `meta` object for ultralong reads were `ultralong_read_dataset` and `ultralong_read_platform` instead of `ultralong_dataset` and `ultralong_platform`, which is what the code assumed they were called.

This means that the ultralong reads were never picked up and passed to hifiasm when specified.

This PR fixes this issue and also updates the hifiasm module to ensure if there are multiple files they are concatenated together.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
