### PR TITLE
fix(hifiasm_assembly): update regular expressions in hifiasm_assembly

### DIFF
--- a/subworkflows/local/hifiasm_assembly/main.nf
+++ b/subworkflows/local/hifiasm_assembly/main.nf
@@ -98,12 +98,12 @@ workflow HIFIASM_ASSEMBLY {
             // hap1/hap2 files - instead we get only p_ctg and a_ctg files, if
             // we don't run in phased or trio mode.
             if(!(asms.find { asm -> asm.name =~ pri } && asms.find { asm -> asm.name =~ alt })) {
-                pri = /^[^.]+\.p_ctg\.fa$/
-                alt = /a_ctg.fa$/
+                pri = /^.+\.p_ctg\.fa$/
+                alt = /^.+\.a_ctg\.fa$/
             }
 
             return [
-                [spec, asms.find { asm -> asm.name =~ pri }, asms.find { asm -> asm.name =~ alt}]
+                [spec, asms.find { asm -> asm.name =~ pri }, asms.find { asm -> asm.name =~ alt }]
             ]
         }
 


### PR DESCRIPTION
Previous regular expression excluded the valid file `asm.bp.p_ctg.fa`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
