### PR TITLE
fix(oatk): correctly publish all files if both plastid and mito not run

### DIFF
--- a/subworkflows/local/oatk_assembly/main.nf
+++ b/subworkflows/local/oatk_assembly/main.nf
@@ -37,7 +37,7 @@ workflow OATK_ASSEMBLY {
     //
     // Logic: combine all oatk outputs into a single map for ease of publishing
     //
-    ch_mito_outputs = OATK.out.log
+    ch_oatk_outputs = OATK.out.log
         .join(OATK.out.mito_fasta, remainder: true)
         .join(OATK.out.mito_bed, remainder: true)
         .join(OATK.out.mito_gfa, remainder: true)

--- a/subworkflows/local/oatk_assembly/main.nf
+++ b/subworkflows/local/oatk_assembly/main.nf
@@ -37,19 +37,19 @@ workflow OATK_ASSEMBLY {
     //
     // Logic: combine all oatk outputs into a single map for ease of publishing
     //
-    ch_oatk_outputs = OATK.out.mito_fasta
-        .join(OATK.out.mito_bed)
-        .join(OATK.out.mito_gfa)
-        .join(OATK.out.annot_mito_txt)
-        .join(OATK.out.pltd_fasta)
-        .join(OATK.out.pltd_bed)
-        .join(OATK.out.pltd_gfa)
-        .join(OATK.out.annot_pltd_txt)
-        .join(OATK.out.initial_gfa)
-        .join(OATK.out.final_gfa)
-        .join(OATK.out.log)
-        .join(BANDAGE_IMAGE.out.png.groupTuple(by: 0))
-        .map { spec, mito_fa, mito_bed, mito_gfa, mito_annot, pltd_fa, pltd_bed, pltd_gfa, pltd_annot, init_gfa, final_gfa, log, images ->
+    ch_mito_outputs = OATK.out.log
+        .join(OATK.out.mito_fasta, remainder: true)
+        .join(OATK.out.mito_bed, remainder: true)
+        .join(OATK.out.mito_gfa, remainder: true)
+        .join(OATK.out.annot_mito_txt, remainder: true)
+        .join(OATK.out.pltd_fasta, remainder: true)
+        .join(OATK.out.pltd_bed, remainder: true)
+        .join(OATK.out.pltd_gfa, remainder: true)
+        .join(OATK.out.annot_pltd_txt, remainder: true)
+        .join(OATK.out.initial_gfa, remainder: true)
+        .join(OATK.out.final_gfa, remainder: true)
+        .join(BANDAGE_IMAGE.out.png.groupTuple(by: 0), remainder: true)
+        .map { spec, log, mito_fa, mito_bed, mito_gfa, mito_annot, pltd_fa, pltd_bed, pltd_gfa, pltd_annot, init_gfa, final_gfa, images ->
             return spec.subMap(["id", "stage", "data", "params", "tools"]) + [
                 output: [
                     oatk: [


### PR DESCRIPTION

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
