### PR TITLE
Fix two small bugs from user reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Note that this update removes the existing Teams and Slack notification functionality. If
     you were using this functionality, please configure the
     [nf-slack](https://github.com/seqeralabs/nf-slack) or [nf-teams](https://github.com/nvnieuwk/nf-teams) Nextflow plugins.
+- [#159](https://github.com/sanger-tol/genomeassembly/pull/159) - Add `--opt-out-run-stats` to BUSCO call when running with a local BUSCO mirror to ensure complete offline capacity (bug reported by @cjfields, fix by @prototaxites)
+- [#159](https://github.com/sanger-tol/genomeassembly/pull/159) - Fix issue in hashing process where the data type name was hashed instead of the dataset name, resulting in clashing hashes (reported by @amakunin and @TannerMyers, fix by @prototaxites)
 
 ### Dependencies
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -55,7 +55,7 @@ process {
         ext.prefix = "asm"
         ext.args = {
             [
-                params.busco_lineage_directory ? "--offline" : "",
+                params.busco_lineage_directory ? "--offline --opt-out-run-stats" : "",
             ].join(" ").trim()
         }
     }

--- a/functions/local/assembly_stages/main.nf
+++ b/functions/local/assembly_stages/main.nf
@@ -118,7 +118,7 @@ def stageSpec(spec, paramsConfig, dataList, haptabList) {
         // Concatenate the data and params values to hash and generate it
         def hashContent = [
             [spec.assembler] +
-            stageData +
+            stageData.collect { type -> "${dataMap[type].id}" } +
             stageParams.collect { k, v -> "${k}=${v}" }
         ].join("&")
 


### PR DESCRIPTION
- When running in offline mode, BUSCO also needs the `--opt-out-run-stats` flag to disable all external connections (fixes part of #154)
- The name of the data set is now correctly hashed instead of the data type, removing an issue which was producing hash collisions when re-using datasets (fixes #158, #153)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/docs/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
