### PR TITLE
feat(busco): supply busco lineage with parameter instead of in assembly spec

### DIFF
--- a/assets/full_tests/test_gfLaeSulp1.spec.yaml
+++ b/assets/full_tests/test_gfLaeSulp1.spec.yaml
@@ -8,7 +8,6 @@
   hifiasm_arguments: "--primary"
   mitohifi_reference_species: "Laetiporus sulphureus"
   mitohifi_mito_genetic_code: 4
-  busco_lineage: dikarya_odb12
 - id: gfLaeSulp1.phased
   assembler: "hifiasm"
   long_read_dataset: gfLaeSulp1
@@ -16,7 +15,6 @@
   hic_dataset: gfLaeSulp1
   phased_assembly: true
   find_mito: false
-  busco_lineage: dikarya_odb12
 - id: gfLaeSulp1.oatk
   assembler: "oatk"
   long_read_dataset: gfLaeSulp1

--- a/assets/full_tests/test_gsMetZobe1.spec.yaml
+++ b/assets/full_tests/test_gsMetZobe1.spec.yaml
@@ -8,7 +8,6 @@
   hifiasm_arguments: "--primary"
   mitohifi_reference_species: "Metschnikowia zobellii"
   mitohifi_mito_genetic_code: 4
-  busco_lineage: dikarya_odb12
 - id: gsMetZobe1.phased
   assembler: "hifiasm"
   long_read_dataset: gsMetZobe1
@@ -16,7 +15,6 @@
   hic_dataset: gsMetZobe1
   phased_assembly: true
   find_mito: false
-  busco_lineage: dikarya_odb12
 - id: gsMetZobe1.oatk
   assembler: "oatk"
   long_read_dataset: gsMetZobe1

--- a/assets/full_tests/test_iyVesGerm1.spec.yaml
+++ b/assets/full_tests/test_iyVesGerm1.spec.yaml
@@ -8,7 +8,6 @@
   hifiasm_arguments: "--primary"
   mitohifi_reference_species: "Vespula germanica"
   mitohifi_mito_genetic_code: 5
-  busco_lineage: insecta_odb12
 - id: iyVesGerm1.phased
   assembler: "hifiasm"
   long_read_dataset: iyVesGerm1
@@ -16,7 +15,6 @@
   hic_dataset: iyVesGerm1
   phased_assembly: true
   find_mito: false
-  busco_lineage: insecta_odb12
 - id: iyVesGerm1.oatk
   assembler: "oatk"
   long_read_dataset: iyVesGerm1

--- a/assets/schema_assembly.json
+++ b/assets/schema_assembly.json
@@ -179,12 +179,6 @@
                 "meta": "yahs_arguments",
                 "default": ""
             },
-            "busco_lineage": {
-                "type": "string",
-                "description": "Lineage name to use for genome completeness assessment using BUSCO, e.g. metazoa_odb12",
-                "meta": "busco_lineage",
-                "default": "auto_euk"
-            },
             "mitohifi_reference_species": {
                 "type": "string",
                 "description": "Binomial name of a taxon to use to find a reference mitochondrial genome.",

--- a/assets/small_tests/default_spec.yaml
+++ b/assets/small_tests/default_spec.yaml
@@ -13,7 +13,6 @@
   mitohifi_mito_reference_fa: https://tolit.cog.sanger.ac.uk/test-data/resources/genomeassembly/mitohifi/PQ668616.1.subset.fasta
   mitohifi_mito_reference_gb: https://tolit.cog.sanger.ac.uk/test-data/resources/genomeassembly/mitohifi/PQ668616.1.subset.gb
   mitohifi_mito_genetic_code: 5
-  busco_lineage: eukaryota_odb12
 - id: icAdaBipu1.phased
   assembler: "hifiasm"
   long_read_dataset: icAdaBipu1
@@ -23,7 +22,6 @@
   find_mito: false
   find_plastid: false
   hifiasm_bin_arguments: "-f0"
-  busco_lineage: eukaryota_odb12
 - id: icAdaBipu1.oatk
   assembler: "oatk"
   long_read_dataset: icAdaBipu1

--- a/assets/small_tests/ont_spec.yaml
+++ b/assets/small_tests/ont_spec.yaml
@@ -11,7 +11,6 @@
   mitohifi_plastid_reference_fa: https://tolit.cog.sanger.ac.uk/test-data/resources/genomeassembly/mitohifi/NC_046388.1.subset.fasta
   mitohifi_plastid_reference_gb: https://tolit.cog.sanger.ac.uk/test-data/resources/genomeassembly/mitohifi/NC_046388.1.subset.gb
   hifiasm_bin_arguments: "-f0"
-  busco_lineage: eukaryota_odb12
 - id: dhQueRobu3.ont
   assembler: "hifiasm"
   long_read_dataset: dhQueRobu3
@@ -21,7 +20,6 @@
   find_mito: false
   find_plastid: false
   hifiasm_bin_arguments: "-f0"
-  busco_lineage: eukaryota_odb12
 - id: dhQueRobu3.oatk
   assembler: "oatk"
   long_read_dataset: dhQueRobu3

--- a/assets/small_tests/trio_spec.yaml
+++ b/assets/small_tests/trio_spec.yaml
@@ -10,7 +10,6 @@
   trio_assembly: true
   hifiasm_bin_arguments: "-f0"
   hifiasm_arguments: ""
-  busco_lineage: eukaryota_odb12
 - id: aBomVar4.mitohifi
   assembler: "mitohifi"
   long_read_dataset: aBomVar4

--- a/conf/test.config
+++ b/conf/test.config
@@ -33,5 +33,6 @@ params {
     // Input data
     genomic_data = "${projectDir}/assets/small_tests/icAdaBipu1_genomic.yaml"
     assembly_specs = "${projectDir}/assets/small_tests/default_spec.yaml"
+    busco_lineage = "eukaryota_odb12"
 
 }

--- a/conf/test_ont.config
+++ b/conf/test_ont.config
@@ -33,5 +33,6 @@ params {
     // Input data
     genomic_data = "${projectDir}/assets/small_tests/dhQueRobu3_genomic.yaml"
     assembly_specs = "${projectDir}/assets/small_tests/ont_spec.yaml"
+    busco_lineage = "eukaryota_odb12"
 
 }

--- a/conf/test_trio.config
+++ b/conf/test_trio.config
@@ -33,5 +33,6 @@ params {
     // Input data
     genomic_data = "${projectDir}/assets/small_tests/aBomVar4_genomic.yaml"
     assembly_specs = "${projectDir}/assets/small_tests/trio_spec.yaml"
+    busco_lineage = "eukaryota_odb12"
 
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,37 +100,36 @@ using GenomeScope2, but if you know the coverage in your sample, you can overrid
 
 These options can be used if the `assembler` field is set to "hifiasm".
 
-| Parameter                       |            | Description                                                                                                                              |
-| ------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `ultralong_dataset`             | -          | Sample identifier from which to find ultra-long reads for Hifiasm assembly. Must have an `oxford_nanopore` platform entry.               |
-| `hic_dataset`                   | -          | Sample identifier from which to find Hi-C reads for phased Hifiasm assembly and scaffolding. Must have an `illumina_hic` platform entry. |
-| `polishing_dataset`             | -          | Sample identifier from which to find 10X reads for polishing. Must have an `illumina_10x` platform entry.                                |
-| `maternal_dataset`              | -          | Sample identifier from which to find maternal reads for trio assembly.                                                                   |
-| `maternal_platform`             | -          | Platform for maternal reads: `illumina`, `illumina_10x`, `pacbio_hifi`, or `oxford_nanopore`.                                            |
-| `paternal_dataset`              | -          | Sample identifier from which to find maternal reads for trio assembly.                                                                   |
-| `paternal_platform`             | -          | Platform for paternal reads: `illumina`, `illumina_10x`, `pacbio_hifi`, or `oxford_nanopore`.                                            |
-| `long_read_1n_coverage`         | -          | Haploid/1n coverage of the target genome in the long read dataset.                                                                       |
-| `phased_assembly`               | `false`    | Produce a phased Hifiasm assembly with Hi-C data. Requires `hic_dataset`.                                                                |
-| `trio_assembly`                 | `false`    | Produce a trio-binned Hifiasm assembly. Requires `maternal_dataset` and `paternal_dataset`.                                              |
-| `purge`                         | `false`    | Purge retained haplotypic duplications using the purge_dups pipeline.                                                                    |
-| `polish`                        | `false`    | Polish the assembly using Illumina 10X data, longranger and FreeBayes.                                                                   |
-| `scaffold`                      | `true`     | Map Hi-C reads and scaffold the assembly using YaHS.                                                                                     |
-| `find_mito`                     | `true`     | Enable mitochondrial genome assembly/search with Mitohifi.                                                                               |
-| `find_plastid`                  | `false`    | Enable plastid genome assembly/search with Mitohifi.                                                                                     |
-| `hifiasm_bin_arguments`         | -          | Additional command-line arguments for Hifiasm overlap graph generation (e.g., error correction options).                                 |
-| `hifiasm_arguments`             | -          | Additional command-line arguments for Hifiasm to produce an assembly.                                                                    |
-| `purging_cutoffs`               | -          | Comma-separated coverage cutoffs for purging (e.g., `"5,20,100"`). Automatically calculated from the coverage if not supplied.           |
-| `purge_middle`                  | `false`    | Purge haplotypic duplications from within contigs, not just at the ends.                                                                 |
-| `yahs_arguments`                | -          | Additional command-line arguments for YaHS.                                                                                              |
-| `busco_lineage`                 | `auto_euk` | BUSCO lineage for completeness assessment (e.g., `metazoa_odb12`).                                                                       |
-| `mitohifi_reference_species`    | -          | Binomial name of taxon for reference mitochondrial genome.                                                                               |
-| `mitohifi_mito_reference_fa`    | -          | Reference FASTA file to use for reference-based mitochondrial genome assembly with MitoHifi.                                             |
-| `mitohifi_mito_reference_gb`    | -          | Reference GenBank file to use for reference-based mitochondrial genome assembly with MitoHifi.                                           |
-| `mitohifi_mito_genetic_code`    | -          | Mitochondrial genetic code for gene prediction.                                                                                          |
-| `mitohifi_plastid_reference_fa` | -          | Reference FASTA file to use for reference-based plastid genome assembly with MitoHifi.                                                   |
-| `mitohifi_plastid_reference_gb` | -          | Reference GenBank file to use for reference-based plastid genome assembly with MitoHifi.                                                 |
-| `mitohifi_plastid_genetic_code` | 11         | Plastid genetic code for gene prediction.                                                                                                |
-| `mitohifi_arguments`            | -          | Extra arguments for MitoHiFi in contigs mode.                                                                                            |
+| Parameter                       |         | Description                                                                                                                              |
+| ------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `ultralong_dataset`             | -       | Sample identifier from which to find ultra-long reads for Hifiasm assembly. Must have an `oxford_nanopore` platform entry.               |
+| `hic_dataset`                   | -       | Sample identifier from which to find Hi-C reads for phased Hifiasm assembly and scaffolding. Must have an `illumina_hic` platform entry. |
+| `polishing_dataset`             | -       | Sample identifier from which to find 10X reads for polishing. Must have an `illumina_10x` platform entry.                                |
+| `maternal_dataset`              | -       | Sample identifier from which to find maternal reads for trio assembly.                                                                   |
+| `maternal_platform`             | -       | Platform for maternal reads: `illumina`, `illumina_10x`, `pacbio_hifi`, or `oxford_nanopore`.                                            |
+| `paternal_dataset`              | -       | Sample identifier from which to find maternal reads for trio assembly.                                                                   |
+| `paternal_platform`             | -       | Platform for paternal reads: `illumina`, `illumina_10x`, `pacbio_hifi`, or `oxford_nanopore`.                                            |
+| `long_read_1n_coverage`         | -       | Haploid/1n coverage of the target genome in the long read dataset.                                                                       |
+| `phased_assembly`               | `false` | Produce a phased Hifiasm assembly with Hi-C data. Requires `hic_dataset`.                                                                |
+| `trio_assembly`                 | `false` | Produce a trio-binned Hifiasm assembly. Requires `maternal_dataset` and `paternal_dataset`.                                              |
+| `purge`                         | `false` | Purge retained haplotypic duplications using the purge_dups pipeline.                                                                    |
+| `polish`                        | `false` | Polish the assembly using Illumina 10X data, longranger and FreeBayes.                                                                   |
+| `scaffold`                      | `true`  | Map Hi-C reads and scaffold the assembly using YaHS.                                                                                     |
+| `find_mito`                     | `true`  | Enable mitochondrial genome assembly/search with Mitohifi.                                                                               |
+| `find_plastid`                  | `false` | Enable plastid genome assembly/search with Mitohifi.                                                                                     |
+| `hifiasm_bin_arguments`         | -       | Additional command-line arguments for Hifiasm overlap graph generation (e.g., error correction options).                                 |
+| `hifiasm_arguments`             | -       | Additional command-line arguments for Hifiasm to produce an assembly.                                                                    |
+| `purging_cutoffs`               | -       | Comma-separated coverage cutoffs for purging (e.g., `"5,20,100"`). Automatically calculated from the coverage if not supplied.           |
+| `purge_middle`                  | `false` | Purge haplotypic duplications from within contigs, not just at the ends.                                                                 |
+| `yahs_arguments`                | -       | Additional command-line arguments for YaHS.                                                                                              |
+| `mitohifi_reference_species`    | -       | Binomial name of taxon for reference mitochondrial genome.                                                                               |
+| `mitohifi_mito_reference_fa`    | -       | Reference FASTA file to use for reference-based mitochondrial genome assembly with MitoHifi.                                             |
+| `mitohifi_mito_reference_gb`    | -       | Reference GenBank file to use for reference-based mitochondrial genome assembly with MitoHifi.                                           |
+| `mitohifi_mito_genetic_code`    | -       | Mitochondrial genetic code for gene prediction.                                                                                          |
+| `mitohifi_plastid_reference_fa` | -       | Reference FASTA file to use for reference-based plastid genome assembly with MitoHifi.                                                   |
+| `mitohifi_plastid_reference_gb` | -       | Reference GenBank file to use for reference-based plastid genome assembly with MitoHifi.                                                 |
+| `mitohifi_plastid_genetic_code` | 11      | Plastid genetic code for gene prediction.                                                                                                |
+| `mitohifi_arguments`            | -       | Extra arguments for MitoHiFi in contigs mode.                                                                                            |
 
 > **Note:** To run reference-based mitochondrial or plastid genome search with MitoHiFi, either `mitohifi_reference_species` or both of `mitohifi_{organelle}_reference_{fa,gb}` must be specified along with `mitohifi_{organelle}_genetic_code`.
 

--- a/functions/local/assembly_stages/main.nf
+++ b/functions/local/assembly_stages/main.nf
@@ -276,7 +276,7 @@ def stageHifiasmSpec(spec, dataList, haptabList) {
     def STAGE_CONFIG = [
         base: [
             data: ["long_read"],
-            params: ["assembler", "hifiasm_bin_arguments", "coverage", "busco_lineage"],
+            params: ["assembler", "hifiasm_bin_arguments", "coverage"],
             enabled: true,
             depends: null,
             extraParams: null,

--- a/main.nf
+++ b/main.nf
@@ -41,6 +41,7 @@ workflow SANGERTOL_GENOMEASSEMBLY {
     val_hic_mapping_cram_chunk_size
     val_scaffolding_cool_bin_size
     val_busco_lineage_directory
+    val_busco_lineage
     val_build_pretext_map
     val_build_juicer_map
     val_build_cooler_map
@@ -61,6 +62,7 @@ workflow SANGERTOL_GENOMEASSEMBLY {
         val_hic_mapping_cram_chunk_size,
         val_scaffolding_cool_bin_size,
         val_busco_lineage_directory,
+        val_busco_lineage,
         val_build_pretext_map,
         val_build_juicer_map,
         val_build_cooler_map,
@@ -121,6 +123,7 @@ workflow {
         params.hic_mapping_cram_chunk_size,
         params.scaffolding_cool_bin_size,
         params.busco_lineage_directory ? file(params.busco_lineage_directory, checkIfExists: true) : null,
+        params.busco_lineage,
         params.build_pretext_map,
         params.build_juicer_map,
         params.build_cooler_map,

--- a/main.nf
+++ b/main.nf
@@ -251,7 +251,7 @@ output {
             spec.output.statistics.busco >> [
                 "${spec.name}",
                 "${specToAssemblyDir(spec)}",
-                "busco.${spec.params.busco_lineage}/"
+                "busco.${params.busco_lineage}/"
             ].join("/")
         }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -40,6 +40,7 @@ params {
 
     // Genome QC options
     busco_lineage_directory = null
+    busco_lineage = "auto_euk"
 
     // Organelle options
     mitohifi_min_ref_len = 15000

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -156,8 +156,14 @@
                     "description": "Path to a local directory containing pre-downloade BUSCO lineages.",
                     "help_text": "Lineage datasets can be downloaded using `busco --download`.",
                     "format": "directory-path"
+                },
+                "busco_lineage": {
+                    "type": "string",
+                    "default": "auto_euk",
+                    "description": "Name of the BUSCO lineage to use for assembly QC. Defaults to \"auto_euk\" which will automatically try to choose the most appropriate eukaryotic BUSCO lineage."
                 }
-            }
+            },
+            "required": ["busco_lineage"]
         },
         "organelle_assembly_options": {
             "title": "Organelle assembly options",

--- a/subworkflows/local/nuclear_assembly/main.nf
+++ b/subworkflows/local/nuclear_assembly/main.nf
@@ -20,6 +20,7 @@ workflow NUCLEAR_ASSEMBLY {
     val_hic_mapping_cram_chunk_size
     val_scaffolding_cool_bin_size
     val_busco_lineage_directory
+    val_busco_lineage
     val_build_pretext_map
     val_build_juicer_map
     val_build_cooler_map
@@ -87,7 +88,7 @@ workflow NUCLEAR_ASSEMBLY {
         .multiMap { spec, hap1, hap2 ->
             assemblies: [spec, hap1, hap2.size() > 0 ? hap2 : []]
             fastk: [spec, spec.data.long_read.fk_hist, spec.data.long_read.fk_ktab, spec.data.maternal.haptab, spec.data.paternal.haptab]
-            busco_lineage: [spec, spec.params.busco_lineage]
+            busco_lineage: [spec, val_busco_lineage]
         }
 
     GENOME_STATISTICS(

--- a/workflows/genomeassembly.nf
+++ b/workflows/genomeassembly.nf
@@ -32,6 +32,7 @@ workflow GENOMEASSEMBLY {
     val_hic_mapping_cram_chunk_size
     val_scaffolding_cool_bin_size
     val_busco_lineage_directory
+    val_busco_lineage
     val_build_pretext_map
     val_build_juicer_map
     val_build_cooler_map
@@ -62,6 +63,7 @@ workflow GENOMEASSEMBLY {
         val_hic_mapping_cram_chunk_size,
         val_scaffolding_cool_bin_size,
         val_busco_lineage_directory,
+        val_busco_lineage,
         val_build_pretext_map,
         val_build_juicer_map,
         val_build_cooler_map,


### PR DESCRIPTION
Realistically this will always be shared among assemblies

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/sanger-tol/genomeassembly/tree/master/docs/CONTRIBUTING.md)
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
